### PR TITLE
Require valid response signature headers from Agent

### DIFF
--- a/src/signify/app/clienting.py
+++ b/src/signify/app/clienting.py
@@ -77,6 +77,7 @@ class SignifyClient:
 
         self.authn = Authenticater(agent=self.agent, ctrl=self.ctrl)
         self.session.auth = SignifyAuth(self.authn)
+        self.session.hooks = dict(response=self.authn.verify)
 
     def approveDelegation(self):
         serder, sigs = self.ctrl.approveDelegation(self.agent)

--- a/src/signify/core/authing.py
+++ b/src/signify/core/authing.py
@@ -4,6 +4,7 @@ KERI
 signify.core.authing module
 
 """
+from urllib.parse import urlparse
 
 from keri import kering
 from keri.app.keeping import SaltyCreator
@@ -234,7 +235,13 @@ class Authenticater:
         self.agent = agent
         self.ctrl = ctrl
 
-    def verify(self, headers, method, path):
+    def verify(self, rep, **kwargs):
+        url = urlparse(rep.request.url)
+        resource = rep.headers["SIGNIFY-RESOURCE"]
+        if resource != self.agent.pre or not self.verifysig(rep.headers, rep.request.method, url.path):
+            raise kering.AuthNError("No valid signature from agent on response.")
+
+    def verifysig(self, headers, method, path):
         headers = headers
         if "SIGNATURE-INPUT" not in headers:
             return False

--- a/tests/app/connect.toml
+++ b/tests/app/connect.toml
@@ -18,13 +18,13 @@ responses:
     auto_calculate_content_length: false
     body: '{"agent": {"v": "KERI10JSON0001e2_", "i": "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei",
       "s": "0", "p": "", "d": "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei", "f":
-      "0", "dt": "2023-05-19T03:05:46.928133+00:00", "et": "dip", "kt": "1", "k":
+      "0", "dt": "2023-05-20T17:46:26.693719+00:00", "et": "dip", "kt": "1", "k":
       ["DMZh_y-H5C3cSbZZST-fqnsmdNTReZxIh0t2xSTOJQ8a"], "nt": "1", "n": ["EM9M2EQNCBK0MyAhVYBvR98Q0tefpvHgE-lHLs82XgqC"],
       "bt": "0", "b": [], "c": [], "ee": {"s": "0", "d": "EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei",
       "br": [], "ba": []}, "di": "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"},
       "controller": {"state": {"v": "KERI10JSON0001b6_", "i": "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose",
       "s": "0", "p": "", "d": "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose", "f":
-      "0", "dt": "2023-05-19T03:05:46.936589+00:00", "et": "icp", "kt": "1", "k":
+      "0", "dt": "2023-05-20T17:46:26.702466+00:00", "et": "icp", "kt": "1", "k":
       ["DAbWjobbaLqRB94KiAutAHb_qzPpOHm3LURA_ksxetVc"], "nt": "1", "n": ["EIFG_uqfr1yN560LoHYHfvPAhxQ5sN6xZZT_E3h7d2tL"],
       "bt": "0", "b": [], "c": [], "ee": {"s": "0", "d": "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose",
       "br": [], "ba": []}, "di": ""}, "ee": {"v": "KERI10JSON00012b_", "t": "icp",
@@ -60,7 +60,7 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '[{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 0, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}}]'
     content_type: text/plain
@@ -77,10 +77,10 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '[{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 0, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}}, {"name": "aid2", "prefix": "EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX",
-      "salty": {"sxlt": "1AAHgQLzYavr_Qq1n9y9HcpZ8YepmYz9YYGA7K7FmsXNFWXeSviEBDwDYMIcAHivQ5muJ3pVZIxCDR2LJsnrd5mscv2dva4KL0ni",
+      "salty": {"sxlt": "1AAHn_2acjrSn_2ta1eYHMtuFmLVgWLtPrBoRYuO4TVNpkJo99lbBhe1P4GEABsm7T8spNin_yeRjQcSpjf8M3YRrA7s6AP6U4vM",
       "pidx": 1, "kidx": 0, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A", "A", "A"], "ncodes": ["A", "A", "A"], "transferable": true}}]'
     content_type: text/plain
@@ -90,12 +90,12 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 0, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}, "transferable": true, "state":
       {"v": "KERI10JSON0001b6_", "i": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
       "s": "0", "p": "", "d": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK", "f":
-      "0", "dt": "2023-05-19T03:05:47.378600+00:00", "et": "icp", "kt": "1", "k":
+      "0", "dt": "2023-05-20T17:46:27.106428+00:00", "et": "icp", "kt": "1", "k":
       ["DPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9"], "nt": "1", "n": ["EAORnRtObOgNiOlMolji-KijC_isa3lRDpHCsol79cOc"],
       "bt": "0", "b": [], "c": [], "ee": {"s": "0", "d": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
       "br": [], "ba": []}, "di": ""}, "windexes": []}'
@@ -113,12 +113,12 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 1, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}, "transferable": true, "state":
       {"v": "KERI10JSON0001e2_", "i": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
       "s": "1", "p": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK", "d": "EBQABdRgaxJONrSLcgrdtbASflkvLxJkiDO0H-XmuhGg",
-      "f": "1", "dt": "2023-05-19T03:05:48.284866+00:00", "et": "rot", "kt": "1",
+      "f": "1", "dt": "2023-05-20T17:46:28.012817+00:00", "et": "rot", "kt": "1",
       "k": ["DHgomzINlGJHr-XP3sv2ZcR9QsIEYS3LJhs4KRaZYKly"], "nt": "1", "n": ["EJMovBlrBuD6BVeUsGSxLjczbLEbZU9YnTSud9K4nVzk"],
       "bt": "0", "b": [], "c": [], "ee": {"s": "1", "d": "EBQABdRgaxJONrSLcgrdtbASflkvLxJkiDO0H-XmuhGg",
       "br": [], "ba": []}, "di": ""}, "windexes": []}'
@@ -136,12 +136,12 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 1, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}, "transferable": true, "state":
       {"v": "KERI10JSON0001e2_", "i": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
       "s": "2", "p": "EBQABdRgaxJONrSLcgrdtbASflkvLxJkiDO0H-XmuhGg", "d": "ENsmRAg_oM7Hl1S-GTRMA7s4y760lQMjzl0aqOQ2iTce",
-      "f": "2", "dt": "2023-05-19T03:05:48.441016+00:00", "et": "ixn", "kt": "1",
+      "f": "2", "dt": "2023-05-20T17:46:28.168752+00:00", "et": "ixn", "kt": "1",
       "k": ["DHgomzINlGJHr-XP3sv2ZcR9QsIEYS3LJhs4KRaZYKly"], "nt": "1", "n": ["EJMovBlrBuD6BVeUsGSxLjczbLEbZU9YnTSud9K4nVzk"],
       "bt": "0", "b": [], "c": [], "ee": {"s": "1", "d": "EBQABdRgaxJONrSLcgrdtbASflkvLxJkiDO0H-XmuhGg",
       "br": [], "ba": []}, "di": ""}, "windexes": []}'
@@ -168,10 +168,10 @@ responses:
 - response:
     auto_calculate_content_length: false
     body: '[{"name": "aid1", "prefix": "ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK",
-      "salty": {"sxlt": "1AAHM4K-xSFXuCm6g7sYStP_0pdlZOm9vYLbER7uplBVT0NBgqDRVPkf6kCkloQXLQORg-UL1ColOihrB1y4vfJ2OQPo5FTdC0Ct",
+      "salty": {"sxlt": "1AAH07xoF1XMXntFswBNkB1_Qm38WI-n6SjGRtdxGiAYZAtk6qYzA5jFgyCRsK8yzwoT8DK22IvpF8YQ8GxeaHNnkWNZIaZbm4Wt",
       "pidx": 0, "kidx": 1, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A"], "ncodes": ["A"], "transferable": true}}, {"name": "aid2", "prefix": "EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX",
-      "salty": {"sxlt": "1AAHgQLzYavr_Qq1n9y9HcpZ8YepmYz9YYGA7K7FmsXNFWXeSviEBDwDYMIcAHivQ5muJ3pVZIxCDR2LJsnrd5mscv2dva4KL0ni",
+      "salty": {"sxlt": "1AAHn_2acjrSn_2ta1eYHMtuFmLVgWLtPrBoRYuO4TVNpkJo99lbBhe1P4GEABsm7T8spNin_yeRjQcSpjf8M3YRrA7s6AP6U4vM",
       "pidx": 1, "kidx": 0, "stem": "signify:aid", "tier": "low", "dcode": "E", "icodes":
       ["A", "A", "A"], "ncodes": ["A", "A", "A"], "transferable": true}}]'
     content_type: text/plain

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -69,7 +69,7 @@ def test_authenticater(mockHelpingNowUTC):
                                  'signify-resource': 'EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs',
                                  'signify-timestamp': '2022-09-24T00:05:48.196795+00:00'}
         req = testing.create_req(method="POST", path="/boot", headers=dict(headers))
-        assert authn.verify(req.headers, "POST", "/boot")
+        assert authn.verifysig(req.headers, "POST", "/boot")
 
 
 def test_agent():


### PR DESCRIPTION
This PR adds a hook to the requests session object that raises an exception if valid HTTP signature headers signed by the Agent aren't found.