### PR TITLE
registryIncept, Longrunning Op for Registry creation

### DIFF
--- a/integration/app/integration_clienting.py
+++ b/integration/app/integration_clienting.py
@@ -348,14 +348,11 @@ def test_registry_creation():
         op = operations.get(op["name"])
         sleep(1)
 
-
-    icp1 = Serder(ked=op["response"])
-
     aid1 = identifiers.get("aid1")
 
     # Make request to create registry
     registries: Registries = client.registries()
-    res = registries.registryIncept(pre=aid1["prefix"],
+    op = registries.registryIncept(pre=aid1["prefix"],
                                     alias="aid1",
                                     name="myregistry",
                                     body={
@@ -363,10 +360,11 @@ def test_registry_creation():
                                         "BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM"],
                                         "toad": 2
                                     })
-    print(res)
+    while not op["done"]:
+        op = operations.get(op["name"])
+        sleep(1)
 
-
-
+    print(op)
 
 
 @_recorder.record(file_path=DELEGATION_FILE_PATH)
@@ -615,7 +613,8 @@ def test_randy():
     aid = aids[0]
     assert aid["prefix"] == icp.pre
 
-    ked = identifiers.interact("aid1", data=[icp.pre])
+    op = identifiers.interact("aid1", data=[icp.pre])
+    ked = op["response"]
     ixn = Serder(ked=ked)
     assert ixn.sn == 1
     assert ixn.ked["a"] == [icp.pre]

--- a/src/signify/app/aiding.py
+++ b/src/signify/app/aiding.py
@@ -4,6 +4,7 @@ from keri import kering
 from keri.app.keeping import Algos
 from keri.core import eventing
 from keri.core.coring import MtrDex, Tholder
+from keri.core.eventing import TraitDex
 from keri.kering import Roles
 from requests import exceptions
 
@@ -195,3 +196,5 @@ class Identifiers:
 
         route = "/end/role/add"
         return eventing.reply(route=route, data=data)
+
+

--- a/src/signify/app/clienting.py
+++ b/src/signify/app/clienting.py
@@ -201,6 +201,10 @@ class SignifyClient:
         from signify.app.coring import Operations
         return Operations(client=self)
 
+    def registries(self):
+        from signify.app.credentialing import Registries
+        return Registries(self)
+
     def oobis(self):
         from signify.app.coring import Oobis
         return Oobis(client=self)

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -1,5 +1,7 @@
+from keri import kering
 from collections import namedtuple
 
+from keri.app.keeping import Algos
 from keri.core import coring
 from keri.core.eventing import TraitDex
 from keri.vdr import eventing
@@ -12,22 +14,51 @@ CredentialTypes = CredentialTypeage(issued='issued', received='received')
 
 
 class Registries:
+    """ Domain class for creating and accessing credential registries. """
 
-    def registryIncept(self, hab, body):
+    def __init__(self, client: SignifyClient):
+        self.client = client
+
+    def registryIncept(self, pre=None, alias=None, name=None, body=None, algo=Algos.salty, **kwargs):
+        # other option
+        if pre is None:
+            raise kering.ValidationError(f"Hab AID prefix required in order to make a registry")
+        if alias is None:
+            raise kering.ValidationError(f"AID alias required in order to make a registry")
+
+        baks = body["baks"] if "baks" in body else None
+        toad = body["toad"] if "toad" in body else None
+        nonce = body["nonce"] if "nonce" in body else None
+        estOnly = body["estOnly"] if "estOnly" in body else False
+
         cnfg = []
         if "noBackers" in body and body["noBackers"]:
             cnfg.append(TraitDex.NoBackers)
-        baks = body["baks"] if "baks" in body else None
-        toad = body["toad"] if "toad" in body else None
-        estOnly = body["estOnly"] if "estOnly" in body else False
-        nonce = body["nonce"] if "nonce" in body else None
+        if estOnly:
+            cnfg.append(TraitDex.EstOnly)
 
-        regser = eventing.incept(hab.pre,
+        regser = eventing.incept(pre,
                                  baks=baks,
                                  toad=toad,
                                  nonce=nonce,
                                  cnfg=cnfg,
                                  code=coring.MtrDex.Blake3_256)
+
+        keeper = self.client.manager.new(algo, self.client.pidx, **kwargs)
+        sigs = keeper.sign(regser.raw)
+
+        json = dict(
+            name=name,
+            alias=alias,
+            sigs=sigs,
+            vcp=regser.ked
+        )
+        json[algo] = keeper.params()
+
+        self.client.pidx = self.client.pidx + 1
+
+        res = self.client.post("/registries", json=json)
+        return res.json()
 
 
 class Credentials:

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -1,9 +1,10 @@
-from keri import kering
 from collections import namedtuple
+from time import sleep
 
+from keri import kering
 from keri.app.keeping import Algos
 from keri.core import coring
-from keri.core.eventing import TraitDex
+from keri.core.eventing import TraitDex, SealEvent
 from keri.vdr import eventing
 
 from signify.app.clienting import SignifyClient
@@ -47,11 +48,24 @@ class Registries:
         keeper = self.client.manager.new(algo, self.client.pidx, **kwargs)
         sigs = keeper.sign(regser.raw)
 
+        rseal = SealEvent(regser.pre, "0", regser.said)
+        rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
+
+        identifiers = self.client.identifiers()
+        operations = self.client.operations()
+        op = identifiers.interact(alias, data=[rseal])
+
+        while not op["done"]:
+            op = operations.get(op["name"])
+            sleep(1)
+        ixn = op["response"]
+
         json = dict(
             name=name,
             alias=alias,
             sigs=sigs,
-            vcp=regser.ked
+            vcp=regser.ked,
+            ixn=ixn
         )
         json[algo] = keeper.params()
 


### PR DESCRIPTION
Adds support using a long running operation for monitoring and waiting on the creation of a credential registry.

This also finishes the `Registries.registryIncept` function which previously did not contain the creation of an anchor Seal for the registry nor the interaction event to add the registry anchor Seal to the KERIA controller's KEL.