### PR TITLE
Update create_person_aid.py

### DIFF
--- a/scripts/create_person_aid.py
+++ b/scripts/create_person_aid.py
@@ -34,6 +34,7 @@ def create_aid():
     ]
 
     op = identifiers.create("BankUser", bran="0123456789abcdefghijk", wits=wits, toad="2")
+    op = op[2]
 
     while not op["done"]:
         op = operations.get(op["name"])


### PR DESCRIPTION
It seems the API for Signifypy has changed since the last update of this script 2 months ago. 

The output from `op = identifiers.create(...)` is a tuple and not a dict. Setting `op` to `op[2]` fixes the script for me.