### PR TITLE
Script for single issuer and single holder ipex grant + admit

### DIFF
--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -5,18 +5,14 @@ signify.app.clienting module
 
 Testing clienting with integration tests that require a running KERIA Cloud Agent
 """
-import json
 from time import sleep
-
-import requests
-import datetime
-import pysodium
-from keri import kering
+from requests import post
+from pysodium import randombytes, crypto_sign_SEEDBYTES
 from keri.app import signing
-from keri.app.keeping import Algos
 from keri.core import coring, eventing
 from keri.core.coring import Tiers
 from keri.help import helping
+from keri.vc.proving import Creder
 from signify.app.clienting import SignifyClient
 
 URL = 'http://127.0.0.1:3901'
@@ -26,7 +22,7 @@ WITNESS_AIDS = ['BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha']
 SCHEMA_OOBI = 'http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
 
 def random_passcode():
-    return coring.Salter(raw=pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)).qb64
+    return coring.Salter(raw=randombytes(crypto_sign_SEEDBYTES)).qb64
 
 def create_timestamp():
     return helping.nowIso8601()
@@ -35,7 +31,7 @@ def connect():
     client = SignifyClient(passcode=random_passcode(), tier=Tiers.low)
 
     evt, siger = client.ctrl.event()
-    res = requests.post(url=BOOT_URL + "/boot",
+    post(url=BOOT_URL + "/boot",
                         json=dict(
                             icp=evt.ked,
                             sig=siger.qb64,
@@ -158,7 +154,7 @@ def run():
         schema=SCHEMA_SAID,
         recipient=holder_prefix,
         data=data)
-    
+
     notification = wait_for_notification(holder_client, '/exn/ipex/grant')
     print(f"Received grant {notification}")
 
@@ -173,8 +169,10 @@ def run():
     while len(credentials) < 1:
         print('No credentials yet...')
         sleep(1)
-  
+
     print('Succeeded')
+    creder = Creder(ked=credentials[0]['sad'])
+    print(creder.pretty(size=5000))
 
 
 if __name__ == "__main__":

--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -169,7 +169,6 @@ def run():
 
     print(f"Listing credentials...")
 
-    sleep(2)
     credentials = holder_client.credentials().list('holder', filtr={})
     while len(credentials) < 1:
         print('No credentials yet...')

--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -1,0 +1,182 @@
+# -*- encoding: utf-8 -*-
+"""
+SIGNIFY
+signify.app.clienting module
+
+Testing clienting with integration tests that require a running KERIA Cloud Agent
+"""
+import json
+from time import sleep
+
+import requests
+import datetime
+import pysodium
+from keri import kering
+from keri.app import signing
+from keri.app.keeping import Algos
+from keri.core import coring, eventing
+from keri.core.coring import Tiers
+from keri.help import helping
+from signify.app.clienting import SignifyClient
+
+URL = 'http://127.0.0.1:3901'
+BOOT_URL = 'http://127.0.0.1:3903'
+SCHEMA_SAID = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+WITNESS_AIDS = []; # ['BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha'];
+SCHEMA_OOBI = 'http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+
+def random_passcode():
+    return coring.Salter(raw=pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)).qb64
+
+def create_timestamp():
+    return helping.nowIso8601()
+
+def connect():
+    client = SignifyClient(passcode=random_passcode(), tier=Tiers.low)
+
+    evt, siger = client.ctrl.event()
+    res = requests.post(url=BOOT_URL + "/boot",
+                        json=dict(
+                            icp=evt.ked,
+                            sig=siger.qb64,
+                            stem=client.ctrl.stem,
+                            pidx=1,
+                            tier=client.ctrl.tier))
+
+    client.connect(url=URL)
+
+    return client
+
+def create_identifier(client: SignifyClient, name: str):
+    result = client.identifiers().create(name, toad=0, wits=[])
+    op = result[2]
+
+    while not op["done"]:
+        op = client.operations.get(op["name"])
+        sleep(1)
+
+    hab = client.identifiers().get(name)
+
+    client.identifiers().addEndRole(name=name, eid=client.agent.pre)
+
+    return hab["prefix"]
+
+def get_agent_oobi(client: SignifyClient, name: str):
+    result = client.oobis().get(name, role='agent')
+    return result["oobis"][0]
+
+
+def resolve_oobi(client: SignifyClient, oobi: str, alias: str):
+    op = client.oobis().resolve(oobi, alias)
+    while not op['done']:
+        op = client.operations().get(op["name"])
+        sleep(1)
+
+def create_registry(client: SignifyClient, name: str, registry_name: str):
+    hab = client.identifiers().get(name)
+    result = client.registries().create(hab=hab, registryName=registry_name)
+    op = result[3]
+    while not op['done']:
+        op = client.operations().get(op["name"])
+        sleep(1)
+
+    registry = client.registries().get(name=name, registryName=registry_name)
+    return registry
+
+def issue_credential(client: SignifyClient, name:str, registry_name: str, schema: str, recipient: str, data):
+    hab = client.identifiers().get(name)
+    registry = client.registries().get(name, registryName=registry_name)
+    creder, iserder, anc, sigs, op = client.credentials().create(hab, registry=registry, data=data, schema=schema, recipient=recipient, timestamp=create_timestamp())
+
+    while not op['done']:
+        print(f"Waiting for creds... {op['name']}")
+        op = client.operations().get(op['name'])
+        sleep(1)
+
+    prefixer = coring.Prefixer(qb64=iserder.pre)
+    seqner = coring.Seqner(sn=iserder.sn)
+    acdc = signing.serialize(creder, prefixer, seqner, iserder.saider)
+    iss = client.registries().serialize(iserder, anc)
+
+    grant, sigs, end = client.ipex().grant(hab, recp=recipient, acdc=acdc,
+                                  iss=iss, message="",
+                                  anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs]),
+                                  dt=create_timestamp())
+
+    client.exchanges().sendFromEvents(name=name, topic="credential", exn=grant, sigs=sigs, atc=end, recipients=[recipient])
+
+    return
+
+def wait_for_notification(client: SignifyClient, route: str):
+    while True:
+        notifications = client.notifications().list()
+        for notif in notifications['notes']:
+            if notif['a']['r'] == route:
+                return notif
+        sleep(1)
+
+def admit_credential(client: SignifyClient, name: str, said: str, recipient: str):
+    dt = create_timestamp()
+    hab = client.identifiers().get(name)
+
+    admit, sigs, end = client.ipex().admit(hab, '', said, dt)
+
+    client.ipex().submitAdmit(name=name, exn=admit, sigs=sigs, atc=end, recp=recipient)
+
+
+def run():
+    issuer_client = connect()
+    holder_client = connect()
+
+    print(f"Holder connected agent {holder_client.agent.pre}")
+    print(f"Issuer connected agent {issuer_client.agent.pre}")
+
+    issuer_prefix = create_identifier(issuer_client, "issuer")
+    holder_prefix = create_identifier(holder_client, "holder")
+
+    print(f"Issuer prefix {issuer_prefix}")
+    print(f"Holder prefix {holder_prefix}")
+
+    issuer_oobi = get_agent_oobi(issuer_client, 'issuer')
+    holder_oobi = get_agent_oobi(holder_client, 'holder')
+    resolve_oobi(issuer_client, holder_oobi, 'holder')
+    resolve_oobi(issuer_client, SCHEMA_OOBI, 'schema')
+    resolve_oobi(holder_client, issuer_oobi, 'issuer')
+    resolve_oobi(holder_client, SCHEMA_OOBI, 'schema')
+
+    registry = create_registry(issuer_client, 'issuer', 'vLEI')
+    print(f"Registry created name={registry['name']}, regk={registry['regk']}")
+
+    data = {
+        "LEI": "5493001KJTIIGC8Y1R17"
+    }
+
+    creds = issue_credential(
+        client=issuer_client,
+        name='issuer',
+        registry_name='vLEI',
+        schema=SCHEMA_SAID,
+        recipient=holder_prefix,
+        data=data)
+    
+    notification = wait_for_notification(holder_client, '/exn/ipex/grant')
+    print(f"Received grant {notification}")
+
+    admit_credential(holder_client, 'holder', notification['a']['d'], issuer_prefix)
+
+    holder_client.notifications().markAsRead(notification['i'])
+    print(f"Notification marked!")
+
+    print(f"Listing credentials...")
+
+    credentials = holder_client.credentials().list('holder', filtr={})
+    # , filtr={'-a-i': holder_prefix})
+    while len(credentials) < 1:
+        print('No credentials yet...')
+        sleep(1)
+  
+    print('Succeeded')
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -22,7 +22,7 @@ from signify.app.clienting import SignifyClient
 URL = 'http://127.0.0.1:3901'
 BOOT_URL = 'http://127.0.0.1:3903'
 SCHEMA_SAID = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
-WITNESS_AIDS = []; # ['BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha'];
+WITNESS_AIDS = ['BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha']
 SCHEMA_OOBI = 'http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
 
 def random_passcode():
@@ -48,11 +48,11 @@ def connect():
     return client
 
 def create_identifier(client: SignifyClient, name: str):
-    result = client.identifiers().create(name, toad=0, wits=[])
+    result = client.identifiers().create(name, toad=str(len(WITNESS_AIDS)), wits=WITNESS_AIDS)
     op = result[2]
 
     while not op["done"]:
-        op = client.operations.get(op["name"])
+        op = client.operations().get(op["name"])
         sleep(1)
 
     hab = client.identifiers().get(name)
@@ -169,8 +169,8 @@ def run():
 
     print(f"Listing credentials...")
 
+    sleep(2)
     credentials = holder_client.credentials().list('holder', filtr={})
-    # , filtr={'-a-i': holder_prefix})
     while len(credentials) < 1:
         print('No credentials yet...')
         sleep(1)


### PR DESCRIPTION
Added reference script for issuing a credential from a single issuer to a single holder using signify.

This is the same steps as used in https://github.com/WebOfTrust/signify-ts/pull/126, that does not work. This script works. However, I you run it without a witness on the issuer AID, keria will respond with an internal server error when listing credentials.