### PR TITLE
fix: use response status_code instead of status

### DIFF
--- a/src/signify/app/notifying.py
+++ b/src/signify/app/notifying.py
@@ -43,7 +43,7 @@ class Notifications:
 
         """
         res = self.client.put(f"/notifications/{nid}", json={})
-        return res.status == 202
+        return res.status_code == 202
 
     def delete(self, nid):
         """ Delete notification
@@ -56,6 +56,4 @@ class Notifications:
 
         """
         res = self.client.delete(path=f"/notifications/{nid}")
-        # TODO: Figure out why res doesn't have status??
-        # return res.status == 202
-        return True
+        return res.status_code == 202

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -41,13 +41,13 @@ def test_noticiation_mark_as_read():
     notes = Notifications(client=mock_client) # type: ignore
 
     from requests import Response
-    mock_response = mock({'status': 202}, spec=Response, strict=True)
+    mock_response = mock({'status_code': 202}, spec=Response, strict=True)
     expect(mock_client, times=1).put('/notifications/ABC123', json={}).thenReturn(mock_response)
 
     out = notes.markAsRead(nid="ABC123")
     assert out is True
 
-    mock_response = mock({'status': 404}, spec=Response, strict=True)
+    mock_response = mock({'status_code': 404}, spec=Response, strict=True)
     expect(mock_client, times=1).put('/notifications/DEF456', json={}).thenReturn(mock_response)
 
     out = notes.markAsRead(nid="DEF456")
@@ -65,17 +65,17 @@ def test_noticiation_delete():
     notes = Notifications(client=mock_client)  # type: ignore
 
     from requests import Response
-    mock_response = mock({'status': 202}, spec=Response, strict=True)
+    mock_response = mock({'status_code': 202}, spec=Response, strict=True)
     expect(mock_client, times=1).delete(path='/notifications/ABC123').thenReturn(mock_response)
 
     out = notes.delete(nid="ABC123")
     assert out is True
 
-    mock_response = mock({'status': 404}, spec=Response, strict=True)
+    mock_response = mock({'status_code': 404}, spec=Response, strict=True)
     expect(mock_client, times=1).delete(path='/notifications/DEF456').thenReturn(mock_response)
 
     out = notes.delete(nid="DEF456")
-    assert out is True
+    assert out is False
 
     verifyNoUnwantedInteractions()
     unstub()


### PR DESCRIPTION
Check for status code was not correct in `notifying.py`. See docs: https://requests.readthedocs.io/en/latest/api/#requests.Response.status_code