### PR TITLE
Update to match the latest CESR 1.1 changes to KERIpy.

### DIFF
--- a/scripts/create_agent.py
+++ b/scripts/create_agent.py
@@ -39,6 +39,7 @@ def create_agent():
                             stem=client.ctrl.stem,
                             pidx=1,
                             tier=client.ctrl.tier))
+    print(res.json())
 
     if res.status_code != requests.codes.accepted:
         raise kering.AuthNError(f"unable to initialize cloud agent connection, {res.status_code}, {res.text}")

--- a/scripts/create_new_quartet.py
+++ b/scripts/create_new_quartet.py
@@ -9,7 +9,7 @@ from time import sleep
 
 import requests
 from keri import kering
-from keri.core import coring
+from keri.core import coring, serdering
 from keri.core.coring import Tiers
 
 from signify.app.clienting import SignifyClient
@@ -131,7 +131,7 @@ def create_aid(client, name, bran, pre):
         op = operations.get(op["name"])
         sleep(1)
 
-    icp = coring.Serder(ked=op["response"])
+    icp = serdering.SerderKERI(sad=op["response"])
     print(icp.pre)
     assert icp.pre == pre
 

--- a/scripts/create_person_aid.py
+++ b/scripts/create_person_aid.py
@@ -40,7 +40,7 @@ def create_aid():
         op = operations.get(op["name"])
         sleep(1)
 
-    icp = coring.Serder(ked=op["response"])
+    icp = serdering.SerderKERI(sad=op["response"])
     assert icp.pre == "EBcIURLpxmVwahksgrsGW6_dUw0zBhyEHYFk17eWrZfk"
     print(f"Person AID {icp.pre} created")
 

--- a/scripts/init_agent.py
+++ b/scripts/init_agent.py
@@ -21,7 +21,7 @@ def create_agent():
     stem = "signify:controller"
 
     ims = input("Type of paste controller inception event:")
-    serder = coring.Serder(raw=ims.encode("utf-8"))
+    serder = serdering.SerderKERIraw=ims.encode("utf-8"))
     siger = coring.Siger(qb64=ims[serder.size:])
 
     res = requests.post(url="http://localhost:3903/boot",

--- a/scripts/join_new_quadlet.py
+++ b/scripts/join_new_quadlet.py
@@ -72,7 +72,7 @@ def accept_join_request(client, name, group):
 
             embeds = exn['e']
             ked = embeds['rot']
-            rot = coring.Serder(ked=ked)
+            rot = serdering.SerderKERI(sad=ked)
 
             keeper = client.manager.get(aid=hab)
             sigs = keeper.sign(ser=rot.raw, indexed=True, indices=[idx], ondices=[odx])

--- a/scripts/list_ipex.py
+++ b/scripts/list_ipex.py
@@ -5,10 +5,7 @@ signify.app.clienting module
 
 Testing clienting with integration tests that require a running KERIA Cloud Agent
 """
-import sys
-
 from keri.core.coring import Tiers
-from keri.vc.proving import Creder
 
 from signify.app.clienting import SignifyClient
 

--- a/scripts/list_person_credentials.py
+++ b/scripts/list_person_credentials.py
@@ -5,9 +5,8 @@ signify.app.clienting module
 
 Testing clienting with integration tests that require a running KERIA Cloud Agent
 """
-
+from keri.core import serdering
 from keri.core.coring import Tiers
-from keri.vc.proving import Creder
 
 from signify.app.clienting import SignifyClient
 
@@ -33,7 +32,7 @@ def list_credentials():
     print(creds)
     assert len(creds) == 1
 
-    creder = Creder(ked=creds[0]['sad'])
+    creder = serdering.SerderACDC(sad=creds[0]['sad'])
     print(creder.pretty(size=5000))
 
     # said = creder.said

--- a/scripts/multisig-create-credential.py
+++ b/scripts/multisig-create-credential.py
@@ -55,7 +55,7 @@ def create_credential():
 
     (_, _, op) = identifiers.create("multisig3", bran="0123456789lmnopqrstuv")
     icp = op["response"]
-    serder = coring.Serder(ked=icp)
+    serder = serdering.SerderKERI(sad=icp)
     assert serder.pre == "EOGvmhJDBbJP4zeXaRun5vSz0O3_1zB10DwNMyjXlJEv"
     print(f"created AID {serder.pre}")
 

--- a/scripts/multisig-holder.py
+++ b/scripts/multisig-holder.py
@@ -76,7 +76,7 @@ def multisig_holder():
         op = client1.operations().get(op['name'])
         sleep(1)
 
-    exn = coring.Serder(ked=op["response"]['exn'])
+    exn = serdering.SerderKERI(sad=op["response"]['exn'])
     print(f"Challenge signed in {exn.said}")
     client1.challenges().responded("holder1", holder2['i'], exn.said)
 
@@ -171,7 +171,7 @@ def create_aid(client, name, bran, expected):
     identifiers = client.identifiers()
     (_, _, op) = identifiers.create(name, bran=bran)
     icp = op["response"]
-    serder = coring.Serder(ked=icp)
+    serder = serdering.SerderKERI(sad=icp)
     assert serder.pre == expected
     print(f"AID Created: {serder.pre}")
 
@@ -220,7 +220,7 @@ def create_admit(client, participant, group, said, recp):
     ipex = client.ipex()
 
     res = exchanges.get(said)
-    grant = coring.Serder(ked=res['exn'])
+    grant = serdering.SerderKERI(sad=res['exn'])
     ghab = get_aid(client, group)
     mhab = get_aid(client, participant)
 

--- a/scripts/multisig-kli-rotation.py
+++ b/scripts/multisig-kli-rotation.py
@@ -42,7 +42,7 @@ def create_multisig():
 
     (_, _, op) = identifiers.create("multisig3", bran="0123456789lmnopqrstuv")
     icp = op["response"]
-    serder = coring.Serder(ked=icp)
+    serder = serdering.SerderKERI(sad=icp)
     assert serder.pre == "EOGvmhJDBbJP4zeXaRun5vSz0O3_1zB10DwNMyjXlJEv"
     print(f"created AID {serder.pre}")
 
@@ -124,17 +124,17 @@ def create_multisig():
         op = operations.get(op["name"])
         sleep(1)
 
-    ixn = coring.Serder(ked=op["response"])
+    ixn = serdering.SerderKERI(sad=op["response"])
     events = client.keyEvents()
     log = events.get(pre=ixn.pre)
     assert len(log) == 2
 
     for event in log:
-        print(coring.Serder(ked=event).pretty())
+        print(serdering.SerderKERI(sad=event).pretty())
 
     (_, _, op2) = identifiers.rotate("multisig3")
     rot = op2["response"]
-    serder = coring.Serder(ked=rot)
+    serder = serdering.SerderKERI(sad=rot)
     print(f"rotated multisig3 to {serder.sn}")
 
     input("hit any key when other two participants have rotated their AIDs")

--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -9,10 +9,9 @@ from time import sleep
 from requests import post
 from pysodium import randombytes, crypto_sign_SEEDBYTES
 from keri.app import signing
-from keri.core import coring, eventing
+from keri.core import coring, eventing, serdering
 from keri.core.coring import Tiers
 from keri.help import helping
-from keri.vc.proving import Creder
 from signify.app.clienting import SignifyClient
 
 URL = 'http://127.0.0.1:3901'
@@ -184,7 +183,7 @@ def run():
         credentials = holder_client.credentials().list('holder', filtr={})
 
     print('Succeeded')
-    creder = Creder(ked=credentials[0]['sad'])
+    creder = serdering.SerderACDC(sad=credentials[0]['sad'])
     print(creder.pretty(size=5000))
 
 

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -85,7 +85,7 @@ class Registries:
     @staticmethod
     def serialize(serder, anc):
         seqner = coring.Seqner(sn=anc.sn)
-        couple = seqner.qb64b + anc.saider.qb64b
+        couple = seqner.qb64b + anc.said.encode("utf-8")
         atc = bytearray()
         atc.extend(coring.Counter(code=coring.CtrDex.SealSourceCouples,
                                   count=1).qb64b)
@@ -197,7 +197,7 @@ class Credentials:
                                     rules=rules,
                                     status=regk)
 
-        dt = creder.subject["dt"] if "dt" in creder.subject else helping.nowIso8601()
+        dt = creder.attrib["dt"] if "dt" in creder.attrib else helping.nowIso8601()
         noBackers = 'NB' in registry['state']['c']
         if noBackers:
             iserder = eventing.issue(vcdig=creder.said, regk=regk, dt=dt)
@@ -221,7 +221,7 @@ class Credentials:
         keeper = self.client.manager.get(aid=hab)
         sigs = keeper.sign(ser=anc.raw)
 
-        res = self.create_from_events(hab=hab, creder=creder.ked, iss=iserder.ked, anc=anc.ked,
+        res = self.create_from_events(hab=hab, creder=creder.sad, iss=iserder.sad, anc=anc.sad,
                                       sigs=sigs)
 
         return creder, iserder, anc, sigs, res.json()

--- a/src/signify/core/authing.py
+++ b/src/signify/core/authing.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 from keri import kering
 from keri.app import keeping
-from keri.core import coring, eventing
+from keri.core import coring, eventing, serdering
 
 from keri.end import ending
 from signify.signifying import State
@@ -74,7 +74,7 @@ class Controller:
                                    toad="0",
                                    wits=[])
         elif type(state) is State:
-            return coring.Serder(ked=state.controller['ee'])
+            return serdering.SerderKERI(sad=state.controller['ee'])
 
     def approveDelegation(self, agent):
         seqner = coring.Seqner(sn=agent.sn)

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -7,7 +7,7 @@ Testing credentialing with unit tests
 """
 from keri.peer import exchanging
 from keri.vdr import eventing as veventing
-from keri.core import eventing
+from keri.core import eventing, coring
 from mockito import mock, unstub, verify, verifyNoUnwantedInteractions, expect, ANY
 
 from signify.app import credentialing
@@ -26,7 +26,8 @@ def test_registries():
 
     from requests import Response
     mock_response = mock({'json': lambda: {}}, spec=Response, strict=True)
-    mock_hab = {'prefix': 'a_prefix', 'name': 'aid1', 'state': {'s': '1', 'd': "ABCDEFG"}}
+    mock_hab = {'prefix': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+                'name': 'aid1', 'state': {'s': '1', 'd': "ABCDEFG"}}
     name = "aid1"
     regName = "reg1"
 
@@ -109,8 +110,10 @@ def test_credentials_create():
     mock_manager = mock(spec=keeping.Manager, strict=True)
     mock_client.manager = mock_manager  # type: ignore
 
-    mock_hab = {'prefix': 'a_prefix', 'name': 'aid1', 'state': {'s': '1', 'd': "ABCDEFG"}}
-    mock_registry = {'regk': "a_regk", 'pre': 'a_prefix', 'state': {'c': ['NB']}}
+    mock_hab = {'prefix': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose', 'name': 'aid1',
+                'state': {'s': '1', 'd': "ABCDEFG"}}
+    mock_registry = {'regk': "EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF",
+                     'pre': 'EHpwssa6tmD2U5W7-aogym-r1NobKBNXydP4MmaebA4O', 'state': {'c': ['NB']}}
     data = dict(dt="2023-09-27T16:27:14.376928+00:00", LEI="ABC1234567890AD4456")
     schema = "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao"
     recp = "ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"
@@ -122,18 +125,29 @@ def test_credentials_create():
     mock_response = mock({}, spec=Response, strict=True)
     expect(mock_response, times=1).json().thenReturn({'v': 'ACDC10JSON00014c_'})
 
-    body = {'acdc': {'v': 'ACDC10JSON00014c_', 'd': 'EPXTb9qRHquoEey-QsF-8Sks8nDoXBK6kdlP1G6WynJ3', 'i': 'a_prefix',
-                     'ri': 'a_regk', 's': 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao',
+    sad = {'v': 'ACDC10JSON00014c_', 'd': '',
+           'i': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+           'ri': 'a_regk', 's': 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao',
+           'a': {'d': 'EHpwssa6tmD2U5W7-aogym-r1NobKBNXydP4MmaebA4O',
+                 'i': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+                 'dt': '2023-09-27T16:27:14.376928+00:00', 'LEI': 'ABC1234567890AD4456'}}
+
+    _, sad = coring.Saider.saidify(sad)
+
+    body = {'acdc': {'v': 'ACDC10JSON000196_', 'd': 'EK2xYrVkfJJHvlGhP79sfEPvQGmkFPPNAj-bjI5oHy7m',
+                     'i': 'EHpwssa6tmD2U5W7-aogym-r1NobKBNXydP4MmaebA4O',
+                     'ri': 'EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF',
+                     's': 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao',
                      'a': {'d': 'EHpwssa6tmD2U5W7-aogym-r1NobKBNXydP4MmaebA4O',
                            'i': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
                            'dt': '2023-09-27T16:27:14.376928+00:00', 'LEI': 'ABC1234567890AD4456'}},
-            'iss': {'v': 'KERI10JSON0000c7_', 't': 'iss', 'd': 'EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF',
-                    'i': 'EPXTb9qRHquoEey-QsF-8Sks8nDoXBK6kdlP1G6WynJ3', 's': '0', 'ri': 'a_regk',
-                    'dt': '2023-09-27T16:27:14.376928+00:00'},
-            'ixn': {'v': 'KERI10JSON0000f1_', 't': 'ixn', 'd': 'EJM1yhn99LOgCPRsEqpg8nKXQjkSE4-Q4dfvF3wm1Waz',
-                    'i': 'a_prefix', 's': '2', 'p': 'ABCDEFG', 'a': [
-                    {'i': 'EPXTb9qRHquoEey-QsF-8Sks8nDoXBK6kdlP1G6WynJ3', 's': '0',
-                     'd': 'EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF'}]}, 'sigs': ['a signature'],
+            'iss': {'v': 'KERI10JSON0000ed_', 't': 'iss', 'd': 'EE8yncw1LCyBVtZPtozAFi7qvGn9dRPwTbuq--ulOAtB',
+                    'i': 'EK2xYrVkfJJHvlGhP79sfEPvQGmkFPPNAj-bjI5oHy7m', 's': '0',
+                    'ri': 'EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF', 'dt': '2023-09-27T16:27:14.376928+00:00'},
+            'ixn': {'v': 'KERI10JSON000115_', 't': 'ixn', 'd': 'EC5KxyucpxnOpIpHe2QUPs9YeH1yGvkALg8NcWLYFe6a',
+                    'i': 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose', 's': '2', 'p': 'ABCDEFG', 'a': [
+                    {'i': 'EK2xYrVkfJJHvlGhP79sfEPvQGmkFPPNAj-bjI5oHy7m', 's': '0',
+                     'd': 'EE8yncw1LCyBVtZPtozAFi7qvGn9dRPwTbuq--ulOAtB'}]}, 'sigs': ['a signature'],
             'salty': {'keeper': 'params'}}
 
     expect(mock_client, times=1).post(f"/identifiers/aid1/credentials", json=body).thenReturn(mock_response)
@@ -141,9 +155,9 @@ def test_credentials_create():
     from signify.app.credentialing import Credentials
     creder, iss, ixn, sigs, op = Credentials(client=mock_client).create(mock_hab, mock_registry, data, schema, recp)
 
-    assert creder.said == "EPXTb9qRHquoEey-QsF-8Sks8nDoXBK6kdlP1G6WynJ3"
-    assert iss.said == "EKRg7i8jS4O6BYUYiQG7X8YiMYdDXdw28tJRhFndCdGF"
-    assert ixn.said == "EJM1yhn99LOgCPRsEqpg8nKXQjkSE4-Q4dfvF3wm1Waz"
+    assert creder.said == "EK2xYrVkfJJHvlGhP79sfEPvQGmkFPPNAj-bjI5oHy7m"
+    assert iss.said == "EE8yncw1LCyBVtZPtozAFi7qvGn9dRPwTbuq--ulOAtB"
+    assert ixn.said == "EC5KxyucpxnOpIpHe2QUPs9YeH1yGvkALg8NcWLYFe6a"
     assert op == {'v': 'ACDC10JSON00014c_'}
 
     verifyNoUnwantedInteractions()

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -1,4 +1,14 @@
+# -*- encoding: utf-8 -*-
+"""
+SIGNIFY
+signify.app.test_authing module
+
+Testing authing with unit tests
+"""
+
 from keri import kering
+from keri.core import serdering
+from keri.core.coring import Tiers
 from mockito import mock, unstub, expect, verifyNoUnwantedInteractions
 import pytest
 
@@ -122,10 +132,20 @@ def test_controller_derive():
 
     from keri.core import coring
     e1 = dict(v=coring.Vstrings.json,
+              t="rot",
               d="",
-              i="ABCDEFG",
-              s="0001",
-              t="rot")
+              i="EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV",
+              s="1",
+              p="EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV",
+              kt="1",
+              k=["DMZy6qbgnKzvCE594tQ4SPs6pIECXTYQBH7BkC4hNY3E"],
+              nt="1",
+              n=["EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV"],
+              bt="0",
+              br=[],
+              ba=[],
+              a=[]
+              )
     
     _, e1 = coring.Saider.saidify(sad=e1)
 
@@ -133,8 +153,11 @@ def test_controller_derive():
     state = State(controller={"ee": e1})
     serder = ctrl.derive(state=state)
 
-    assert serder.raw == (b'{"v":"KERI10JSON00006f_","d":"EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F",'
-                          b'"i":"ABCDEFG","s":"0001","t":"rot"}')
+    assert serder.raw == (b'{"v":"KERI10JSON000160_","t":"rot","d":"ENvjVqUoq2SGDrFSzqI5AI37ZE4IAlKLdFGw'
+                          b'Uzf7Ir7I","i":"EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV","s":"1","p":"EM'
+                          b'PYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV","kt":"1","k":["DMZy6qbgnKzvCE594'
+                          b'tQ4SPs6pIECXTYQBH7BkC4hNY3E"],"nt":"1","n":["EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8'
+                          b'A3jjXxqYawLcV"],"bt":"0","br":[],"ba":[],"a":[]}')
 
 
 def test_approve_delegation():
@@ -160,7 +183,7 @@ def test_approve_delegation():
         pre="EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV", 
         dig="EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV", 
         sn=1,
-        data=[{'i': 'pre', 's': '1', 'd': 'said'}]).thenReturn(coring.Serder(ked=e1))
+        data=[{'i': 'pre', 's': '1', 'd': 'said'}]).thenReturn(serdering.SerderKERI(sad=e1))
 
     serder, sig = ctrl.approveDelegation(agent=mock_agent)
     


### PR DESCRIPTION
This PR provides updates to match the latest CESR 1.1 changes to KERIpy.  Includes replacing Serder with SerderKERI and Creder with SerderACDC.