### PR TITLE
Catching up to latest KERIpy.

### DIFF
--- a/scripts/init_agent.py
+++ b/scripts/init_agent.py
@@ -9,7 +9,7 @@ Testing clienting with integration tests that require a running KERIA Cloud Agen
 import pytest
 import requests
 from keri import kering
-from keri.core import coring
+from keri.core import coring, serdering
 from keri.core.coring import Tiers
 
 from signify.app.clienting import SignifyClient
@@ -21,7 +21,7 @@ def create_agent():
     stem = "signify:controller"
 
     ims = input("Type of paste controller inception event:")
-    serder = serdering.SerderKERIraw=ims.encode("utf-8"))
+    serder = serdering.SerderKERI(raw=ims.encode("utf-8"))
     siger = coring.Siger(qb64=ims[serder.size:])
 
     res = requests.post(url="http://localhost:3903/boot",

--- a/src/signify/peer/exchanging.py
+++ b/src/signify/peer/exchanging.py
@@ -80,7 +80,7 @@ class Exchanges:
         Parameters:
             name (str): human readable identifier alias to send from
             topic (Str): message topic
-            exn (Serder): peer-to-peer message to send
+            exn (SerderKERI): peer-to-peer message to send
             sigs (list): qb64 signatures over the exn
             atc (string|bytes): additional attachments for exn (usually pathed signatures over embeds)
             recipients (list[string]): list of qb64 recipient AIDs

--- a/tests/app/test_aiding.py
+++ b/tests/app/test_aiding.py
@@ -72,8 +72,8 @@ def test_aiding_create():
 
     expect(mock_keeper, times=1).incept(transferable=True).thenReturn((keys, ndigs))
 
-    from keri.core import coring
-    mock_serder = mock({'raw': b'raw bytes', 'ked': {'a': 'key event dictionary'}}, spec=coring.Serder, strict=True)
+    from keri.core import serdering
+    mock_serder = mock({'raw': b'raw bytes', 'ked': {'a': 'key event dictionary'}}, spec=serdering.SerderKERI, strict=True)
 
     from keri.core import eventing
     expect(eventing, times=1).incept(keys=keys, isith='1', nsith='1', ndigs=ndigs, code='E', wits=[], toad='0', data=[]).thenReturn(mock_serder)
@@ -114,8 +114,8 @@ def test_aiding_create_delegation():
 
     expect(mock_keeper, times=1).incept(transferable=True).thenReturn((keys, ndigs))
 
-    from keri.core import coring
-    mock_serder = mock({'raw': b'raw bytes', 'ked': {'a': 'key event dictionary'}}, spec=coring.Serder, strict=True)
+    from keri.core import serdering
+    mock_serder = mock({'raw': b'raw bytes', 'ked': {'a': 'key event dictionary'}}, spec=serdering.SerderKERI, strict=True)
 
     from keri.core import eventing
     expect(eventing, times=1).delcept(keys=['a signer verfer qb64'], delpre='my delegation', isith='1', nsith='1',
@@ -234,8 +234,9 @@ def test_aiding_interact_no_data():
     mock_hab = {'prefix': 'hab prefix', 'name': 'aid1', 'state': {'s': '0', 'd': 'hab digest'}}
     expect(ids, times=1).get('aid1').thenReturn(mock_hab)
 
-    from keri.core import eventing, coring
-    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=coring.Serder, strict=True)
+    from keri.core import eventing, serdering
+    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=serdering.SerderKERI,
+                       strict=True)
     expect(eventing, times=1).interact('hab prefix', sn=1, data=[None], dig='hab digest').thenReturn(mock_serder)
 
     mock_keeper = mock({'algo': 'salty', 'params': lambda: {'keeper': 'params'}}, spec=keeping.SaltyKeeper, strict=True)
@@ -273,8 +274,8 @@ def test_aiding_interact_with_data():
     mock_hab = {'prefix': 'hab prefix', 'name': 'aid1', 'state': {'s': '0', 'd': 'hab digest'}}
     expect(ids, times=1).get('aid1').thenReturn(mock_hab)
 
-    from keri.core import eventing, coring
-    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=coring.Serder, strict=True)
+    from keri.core import eventing, serdering
+    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=serdering.SerderKERI, strict=True)
     expect(eventing, times=1).interact('hab prefix', sn=1, data=[{'some': 'data'}, {'some': 'more'}], dig='hab digest').thenReturn(
         mock_serder)
 
@@ -323,8 +324,8 @@ def test_aiding_rotate():
     expect(mock_keeper, times=1).rotate(ncodes=['A'], transferable=True, states=[{'i': 'state 1'}, {'i': 'state 2'}],
                              rstates=[{'i': 'rstate 1'}, {'i': 'rstate 2'}]).thenReturn((keys, ndigs))
 
-    from keri.core import coring
-    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=coring.Serder, strict=True)
+    from keri.core import serdering
+    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=serdering.SerderKERI, strict=True)
 
     from keri.core import eventing
     expect(eventing, times=1).rotate(pre='hab prefix', keys=['key1'], dig='hab digest', sn=1, isith='1', nsith='1',
@@ -362,8 +363,8 @@ def test_aiding_add_end_role():
     mock_hab = {'prefix': 'hab prefix', 'name': 'aid1'}
     expect(ids, times=1).get('aid1').thenReturn(mock_hab)
 
-    from keri.core import coring
-    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=coring.Serder, strict=True)
+    from keri.core import serdering
+    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=serdering.SerderKERI, strict=True)
     expect(ids, times=1).makeEndRole('hab prefix', 'agent', None, None).thenReturn(mock_serder)
 
     from signify.core import keeping
@@ -397,8 +398,8 @@ def test_aiding_sign():
     from signify.app.aiding import Identifiers
     ids = Identifiers(client=mock_client) # type: ignore
 
-    from keri.core import coring
-    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=coring.Serder, strict=True)
+    from keri.core import serdering
+    mock_serder = mock({'ked': {'a': 'key event dictionary'}, 'raw': b'serder raw bytes'}, spec=serdering.SerderKERI, strict=True)
 
     mock_hab = {'prefix': 'hab prefix', 'name': 'aid1'}
     expect(ids, times=1).get('aid1').thenReturn(mock_hab)
@@ -422,7 +423,7 @@ def test_aiding_member():
     mock_client = mock(spec=SignifyClient, strict=True)
 
     from signify.app.aiding import Identifiers
-    ids = Identifiers(client=mock_client) # type: ignore
+    ids = Identifiers(client=mock_client)  # type: ignore
 
     from requests import Response
     mock_response = mock(spec=Response, strict=True)

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -88,8 +88,8 @@ def test_grouping_join():
     groups = Groups(client=mock_client)  # type: ignore
 
     from requests import Response
-    from keri.core.coring import Serder
-    mock_rot = mock({'ked': {}}, spec=Serder, strict=True)
+    from keri.core.serdering import SerderKERI
+    mock_rot = mock({'ked': {}}, spec=SerderKERI, strict=True)
     mock_sigs = ['sig']
     mock_smids = ['1', '2', '3']
     mock_rmids = ['a', 'b', 'c']


### PR DESCRIPTION
This PR finishes the updates to catch SigPy up to the latests changes for KERIpy.  It also fixes a few references to sequence number that were formatted incorrectly.