### PR TITLE
Update challenge and credential endpoints to remove unneeded path parameters

### DIFF
--- a/src/signify/app/challenging.py
+++ b/src/signify/app/challenging.py
@@ -41,11 +41,10 @@ class Challenges:
 
         return res
 
-    def verify(self, name, source, words):
+    def verify(self, source, words):
         """ Ask Agent to verify a given sender signed the provided words
 
         Parameters:
-            name (str): human readable name of AID environment
             source(str): qb64 AID of source of challenge response to check for
             words(list): list of challenge words to check for
         """
@@ -54,14 +53,13 @@ class Challenges:
             words=words
         )
 
-        res = self.client.post(f"/challenges/{name}/verify/{source}", json=json)
+        res = self.client.post(f"/challenges_verify/{source}", json=json)
         return res.json()
 
-    def responded(self, name, source, said):
+    def responded(self, source, said):
         """ Mark challenge response as signed and accepted
 
         Parameters:
-            name (str): human readable name of AID environment
             source (str): qb64 AID of signer
             said (str): qb64 AID of exn message representing the signed response
 
@@ -73,5 +71,5 @@ class Challenges:
             said=said
         )
 
-        self.client.put(f"/challenges/{name}/verify/{source}", json=json)
+        self.client.put(f"/challenges_verify/{source}", json=json)
         return True

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -144,11 +144,10 @@ class Credentials:
         res = self.client.post(f"/credentials/query", json=json)
         return res.json()
 
-    def export(self, name, said):
+    def export(self, said):
         """
 
         Parameters:
-            name (str): Name associated with the AID
             said (str): SAID of credential to export
         Returns:
             credential (bytes): exported credential
@@ -156,7 +155,7 @@ class Credentials:
         """
         headers = dict(accept="application/json+cesr")
 
-        res = self.client.get(f"/identifiers/{name}/credentials/{said}", headers=headers)
+        res = self.client.get(f"/credentials/{said}", headers=headers)
         return res.content
 
     def create(self, hab, registry, data, schema, recipient=None, edges=None, rules=None, private=False,

--- a/tests/app/test_challenging.py
+++ b/tests/app/test_challenging.py
@@ -42,13 +42,13 @@ def test_challenge_verify():
     words = ["word", "one", "two", "three"]
     from requests import Response
     mock_response = mock({}, spec=Response, strict=True)
-    expect(mock_client, times=1).post(f'/challenges/{name}/verify/{source}',
+    expect(mock_client, times=1).post(f'/challenges_verify/{source}',
                                       json=dict(words=words)).thenReturn(mock_response)
     expect(mock_response, times=1).json().thenReturn(
         {"done": False}
     )
 
-    out = chas.verify(name, source, words)
+    out = chas.verify(source, words)
     assert out["done"] is False
 
     verifyNoUnwantedInteractions()
@@ -67,10 +67,10 @@ def test_challenge_responded():
     said = "E456"
     from requests import Response
     mock_response = mock({}, spec=Response, strict=True)
-    expect(mock_client, times=1).put(f'/challenges/{name}/verify/{source}',
+    expect(mock_client, times=1).put(f'/challenges_verify/{source}',
                                      json=dict(said=said)).thenReturn(mock_response)
 
-    out = chas.responded(name, source, said)
+    out = chas.responded(source, said)
     assert out is True
 
     verifyNoUnwantedInteractions()

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -90,11 +90,11 @@ def test_credentials_export():
 
     from requests import Response
     mock_response = mock({'content': 'things I found'}, spec=Response, strict=True)
-    expect(mock_client, times=1).get('/identifiers/aid1/credentials/a_said',
+    expect(mock_client, times=1).get('/credentials/a_said',
                                      headers={'accept': 'application/json+cesr'}).thenReturn(mock_response)
 
     from signify.app.credentialing import Credentials
-    out = Credentials(client=mock_client).export('aid1', 'a_said')  # type: ignore
+    out = Credentials(client=mock_client).export('a_said')  # type: ignore
 
     assert out == 'things I found'
 


### PR DESCRIPTION
This PR matches the reroute PR from KERIA to remove `/identifiers/{name}` from several endpoints where it wasn't needed.