### PR TITLE
fixes rename in keripy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ],
     python_requires='>=3.12.1',
     install_requires=[
-        'keri>=1.1.0',
+        'keri @ git+https://git@github.com/weboftrust/keripy.git@development',
         'multicommand>=1.0.0',
         'requests>=2.28',
         'http_sfv>=0.9.8',

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -41,7 +41,7 @@ class Registries:
 
         cnfg = []
         if noBackers:
-            cnfg.append(TraitDex.NoBackers)
+            cnfg.append(TraitDex.NoRegistrarBackers)
         if estOnly:
             cnfg.append(TraitDex.EstOnly)
 


### PR DESCRIPTION
Merging this will require moving to latest keripy:development, currently we point to 1.1.0