### PR TITLE
chore,test: upgrade to KERIpy 1.2.3 and fix tests; add docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,17 @@ jobs:
         os: [ macos-latest, ubuntu-latest ]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.12.2
+      - uses: actions/checkout@v4.2.2
+      - name: Set up Python 3.12.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12.2
+          python-version: 3.12.6
+      # This is needed so MacOS can find the libsodium library installed by Homebrew
+      - name: Install dependencies for MacOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          export DYLD_LIBRARY_PATH="/usr/local/lib:/opt/homebrew/lib:$DYLD_LIBRARY_PATH"
+          echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/scripts/init_agent.py
+++ b/scripts/init_agent.py
@@ -9,7 +9,7 @@ Testing clienting with integration tests that require a running KERIA Cloud Agen
 import pytest
 import requests
 from keri import kering
-from keri.core import coring, serdering
+from keri.core import coring, serdering, signing
 from keri.core.coring import Tiers
 
 from signify.app.clienting import SignifyClient
@@ -22,7 +22,7 @@ def create_agent():
 
     ims = input("Type of paste controller inception event:")
     serder = serdering.SerderKERI(raw=ims.encode("utf-8"))
-    siger = coring.Siger(qb64=ims[serder.size:])
+    siger = signing.Siger(qb64=ims[serder.size:])
 
     res = requests.post(url="http://localhost:3903/boot",
                         json=dict(

--- a/scripts/join_new_multisig_issuer.py
+++ b/scripts/join_new_multisig_issuer.py
@@ -7,7 +7,7 @@ join new quadlet script
 
 from time import sleep
 
-from keri.core import eventing, coring, serdering
+from keri.core import eventing, serdering, signing
 from keri.core.coring import Tiers
 from signify.app.clienting import SignifyClient
 
@@ -83,7 +83,7 @@ def accept_join_request(client, name, group):
             op = groups.join(group, rot, sigs, gid, smids, rmids)
 
             embeds = dict(
-                rot=eventing.messagize(serder=rot, sigers=[coring.Siger(qb64=sig) for sig in sigs])
+                rot=eventing.messagize(serder=rot, sigers=[signing.Siger(qb64=sig) for sig in sigs])
             )
 
             exchanges.send(name, "multisig", sender=hab, route="/multisig/rot",

--- a/scripts/join_new_quadlet.py
+++ b/scripts/join_new_quadlet.py
@@ -7,7 +7,7 @@ join new quadlet script
 
 from time import sleep
 
-from keri.core import eventing, coring, serdering
+from keri.core import eventing, coring, serdering, signing
 from keri.core.coring import Tiers
 from signify.app.clienting import SignifyClient
 
@@ -80,7 +80,7 @@ def accept_join_request(client, name, group):
             op = groups.join(group, rot, sigs, gid, smids, rmids)
 
             embeds = dict(
-                rot=eventing.messagize(serder=rot, sigers=[coring.Siger(qb64=sig) for sig in sigs])
+                rot=eventing.messagize(serder=rot, sigers=[signing.Siger(qb64=sig) for sig in sigs])
             )
 
             exchanges.send(name, "multisig", sender=hab, route="/multisig/rot",

--- a/scripts/multisig-create-credential.py
+++ b/scripts/multisig-create-credential.py
@@ -12,6 +12,7 @@ from keri import kering
 from keri.app import signing
 from keri.app.keeping import Algos
 from keri.core import coring, eventing, serdering
+from keri.core import signing as csigning
 from keri.core.coring import Tiers
 from signify.app.clienting import SignifyClient
 
@@ -106,7 +107,7 @@ def create_credential():
     recp = [state['i'] for state in [multisig2, multisig1]]
 
     embeds = dict(
-        icp=eventing.messagize(serder=icp, sigers=[coring.Siger(qb64=sig) for sig in isigs])
+        icp=eventing.messagize(serder=icp, sigers=[csigning.Siger(qb64=sig) for sig in isigs])
     )
 
     exchanges.send("multisig3", "multisig", sender=m3, route="/multisig/icp",
@@ -136,7 +137,7 @@ def create_credential():
 
     embeds = dict(
         vcp=vcp.raw,
-        anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in rsigs])
+        anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in rsigs])
     )
 
     recp = ["EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4", "EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1"]
@@ -170,7 +171,7 @@ def create_credential():
     embeds = dict(
         acdc=acdc,
         iss=iss,
-        anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs])
+        anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in sigs])
     )
     exchanges.send("multisig3", "multisig", sender=m3, route="/multisig/iss",
                    payload=dict(gid=m["prefix"]),
@@ -184,12 +185,12 @@ def create_credential():
     m = identifiers.get("multisig")
     grant, sigs, end = ipex.grant(m, recp="ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k", acdc=acdc,
                                   iss=iss, message="",
-                                  anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs]),
+                                  anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in sigs]),
                                   dt=TIME)
 
     mstate = m["state"]
     seal = eventing.SealEvent(i=m["prefix"], s=mstate["ee"]["s"], d=mstate["ee"]["d"])
-    ims = eventing.messagize(serder=grant, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=grant, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     ims.extend(end)
     embeds = dict(
         exn=ims

--- a/scripts/multisig-holder.py
+++ b/scripts/multisig-holder.py
@@ -13,6 +13,7 @@ from keri import kering
 from keri.app import signing
 from keri.app.keeping import Algos
 from keri.core import coring, eventing, serdering
+from keri.core import signing as csigning
 from keri.core.coring import Tiers
 from keri.help import helping
 
@@ -216,7 +217,7 @@ def create_multisig(client, name, member, states):
     recps = [x['i'] for x in states if x['i'] != member['prefix']]
 
     embeds = dict(
-        icp=eventing.messagize(serder=icp, sigers=[coring.Siger(qb64=sig) for sig in isigs])
+        icp=eventing.messagize(serder=icp, sigers=[csigning.Siger(qb64=sig) for sig in isigs])
     )
 
     exchanges.send(member['name'], "multisig", sender=member, route="/multisig/icp",
@@ -239,7 +240,7 @@ def create_admit(client, participant, group, said, recp):
 
     mstate = ghab["state"]
     seal = eventing.SealEvent(i=ghab["prefix"], s=mstate["ee"]["s"], d=mstate["ee"]["d"])
-    ims = eventing.messagize(serder=admit, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=admit, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     ims.extend(end)
     embeds = dict(
         exn=ims
@@ -280,7 +281,7 @@ def add_end_role_multisig(client, name, ghab, m, eid, stamp=None):
 
     gstate = ghab["state"]
     seal = eventing.SealEvent(i=ghab["prefix"], s=gstate["ee"]["s"], d=gstate["ee"]["d"])
-    ims = eventing.messagize(serder=rpy, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=rpy, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     embeds = dict(
         rpy=ims
     )
@@ -339,7 +340,7 @@ def create_credential(client, holder):
 
     grant, sigs, end = ipex.grant(issuer, recp=holder['i'], acdc=acdc,
                                   iss=iss, message="",
-                                  anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs]))
+                                  anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in sigs]))
     print(f"Sending grant {grant.said}")
     exchanges.sendFromEvents("issuer", "credential", grant, sigs, end, [holder['i']])
     print("... sent")

--- a/scripts/multisig-issuer-holder.py
+++ b/scripts/multisig-issuer-holder.py
@@ -12,6 +12,7 @@ from keri import kering
 from keri.app import signing
 from keri.app.keeping import Algos
 from keri.core import coring, eventing, serdering
+from keri.core import signing as csigning
 from keri.core.coring import Tiers
 from keri.help import helping
 
@@ -306,7 +307,7 @@ def create_multisig(client, name, member, states):
     recps = [x['i'] for x in states if x['i'] != member['prefix']]
 
     embeds = dict(
-        icp=eventing.messagize(serder=icp, sigers=[coring.Siger(qb64=sig) for sig in isigs])
+        icp=eventing.messagize(serder=icp, sigers=[csigning.Siger(qb64=sig) for sig in isigs])
     )
 
     exchanges.send(member['name'], "multisig", sender=member, route="/multisig/icp",
@@ -330,7 +331,7 @@ def create_admit(client, participant, group, said, recp, stamp):
     print(f"created ADMIT {admit.said}")
     mstate = ghab["state"]
     seal = eventing.SealEvent(i=ghab["prefix"], s=mstate["ee"]["s"], d=mstate["ee"]["d"])
-    ims = eventing.messagize(serder=admit, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=admit, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     ims.extend(end)
     embeds = dict(
         exn=ims
@@ -370,7 +371,7 @@ def add_end_role_multisig(client, name, ghab, m, eid, stamp=None):
 
     gstate = ghab["state"]
     seal = eventing.SealEvent(i=ghab["prefix"], s=gstate["ee"]["s"], d=gstate["ee"]["d"])
-    ims = eventing.messagize(serder=rpy, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=rpy, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     embeds = dict(
         rpy=ims
     )
@@ -405,7 +406,7 @@ def create_registry(client, localName, groupName, recp, name, nonce):
 
     embeds = dict(
         vcp=vcp.raw,
-        anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in rsigs])
+        anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in rsigs])
     )
 
     exchanges.send(localName, groupName, sender=local, route="/multisig/vcp",
@@ -440,7 +441,7 @@ def create_credential(client, localName, groupName, recp, registryName, holder, 
     embeds = dict(
         acdc=acdc,
         iss=iss,
-        anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs])
+        anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in sigs])
     )
     exchanges.send(localName, groupName, sender=local, route="/multisig/iss",
                    payload=dict(gid=issuer["prefix"]),
@@ -465,12 +466,12 @@ def create_grant(client, localName, groupName, creder, iserder, anc, sigs, recp,
 
     grant, sigs, end = ipex.grant(issuer, recp=holder, acdc=acdc,
                                   iss=iss, message="", dt=stamp,
-                                  anc=eventing.messagize(serder=anc, sigers=[coring.Siger(qb64=sig) for sig in sigs]))
+                                  anc=eventing.messagize(serder=anc, sigers=[csigning.Siger(qb64=sig) for sig in sigs]))
 
     print(f'created grant {grant.said}')
     mstate = issuer["state"]
     seal = eventing.SealEvent(i=issuer["prefix"], s=mstate["ee"]["s"], d=mstate["ee"]["d"])
-    ims = eventing.messagize(serder=grant, sigers=[coring.Siger(qb64=sig) for sig in sigs], seal=seal)
+    ims = eventing.messagize(serder=grant, sigers=[csigning.Siger(qb64=sig) for sig in sigs], seal=seal)
     ims.extend(end.encode("utf-8"))
     embeds = dict(
         exn=ims

--- a/scripts/multisig-kli-rotation.py
+++ b/scripts/multisig-kli-rotation.py
@@ -3,7 +3,7 @@ from time import sleep
 import requests
 from keri import kering
 from keri.app.keeping import Algos
-from keri.core import coring, eventing
+from keri.core import coring, eventing, signing
 from keri.core.coring import Tiers
 from signify.app.clienting import SignifyClient
 
@@ -93,7 +93,7 @@ def create_multisig():
     recp = [state['i'] for state in [multisig2, multisig1]]
 
     embeds = dict(
-        icp=eventing.messagize(serder=icp, sigers=[coring.Siger(qb64=sig) for sig in isigs])
+        icp=eventing.messagize(serder=icp, sigers=[signing.Siger(qb64=sig) for sig in isigs])
     )
 
     exchanges.send("multisig3", "multisig", sender=m3, route="/multisig/icp",
@@ -112,7 +112,7 @@ def create_multisig():
     ixn, xsigs, op = identifiers.interact("multisig", data=data)
 
     embeds = dict(
-        ixn=eventing.messagize(serder=ixn, sigers=[coring.Siger(qb64=sig) for sig in xsigs])
+        ixn=eventing.messagize(serder=ixn, sigers=[signing.Siger(qb64=sig) for sig in xsigs])
     )
 
     exchanges.send("multisig3", "multisig", sender=m3, route="/multisig/ixn",
@@ -165,7 +165,7 @@ def create_multisig():
 
     rot, rsigs, op = identifiers.rotate("multisig", states=states, rstates=rstates)
     embeds = dict(
-        rot=eventing.messagize(serder=rot, sigers=[coring.Siger(qb64=sig) for sig in rsigs])
+        rot=eventing.messagize(serder=rot, sigers=[signing.Siger(qb64=sig) for sig in rsigs])
     )
 
     smids = [state['i'] for state in states]

--- a/scripts/single-issuer-holder.py
+++ b/scripts/single-issuer-holder.py
@@ -9,6 +9,7 @@ from time import sleep
 from requests import post
 from pysodium import randombytes, crypto_sign_SEEDBYTES
 from keri.app import signing
+from keri.core import signing as csigning
 from keri.core import coring, eventing, serdering
 from keri.core.coring import Tiers
 from keri.help import helping
@@ -22,7 +23,7 @@ SCHEMA_OOBI = 'http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4Mmv
 
 
 def random_passcode():
-    return coring.Salter(raw=randombytes(crypto_sign_SEEDBYTES)).qb64
+    return csigning.Salter(raw=randombytes(crypto_sign_SEEDBYTES)).qb64
 
 
 def create_timestamp():
@@ -104,7 +105,7 @@ def issue_credential(client: SignifyClient, name: str, registry_name: str, schem
     grant, sigs, end = client.ipex().grant(hab, recp=recipient, acdc=acdc,
                                            iss=iss, message="",
                                            anc=eventing.messagize(serder=anc,
-                                                                  sigers=[coring.Siger(qb64=sig) for sig in sigs]),
+                                                                  sigers=[csigning.Siger(qb64=sig) for sig in sigs]),
                                            dt=create_timestamp())
 
     client.exchanges().sendFromEvents(name=name, topic="credential", exn=grant, sigs=sigs, atc=end,

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,23 @@ https://caremad.io/posts/2013/07/setup-vs-requirement/
 from glob import glob
 from os.path import basename
 from os.path import splitext
+from pathlib import Path
 
 from setuptools import find_packages, setup
+
+# Prepares a nice long description for PyPi based on the README.md file
+this_directory = Path(__file__).parent
+if (this_directory / "README.md").exists():  # If building inside a container this file won't exist and fails the build
+    long_description = (this_directory / "README.md").read_text()
+else:
+    long_description = "KERI Signing at the Edge Infrastructure"
+
 setup(
     name='signifypy',
-    version='0.1.1',  # also change in src/signify/__init__.py
+    version='0.1.2',  # also change in src/signify/__init__.py
     license='Apache Software License 2.0',
-    description='Signify',
-    long_description="KERI Signing at the Edge Infrastructure",
+    description='SignifyPy: KERI Signing at the Edge',
+    long_description=long_description,
     author='Philip S. Feairheller',
     author_email='pfeairheller@gmail.com',
     url='https://github.com/WebOfTrust/signifypy',
@@ -51,7 +60,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Utilities',
     ],
@@ -59,29 +68,45 @@ setup(
         'Documentation': 'https://signifypy.readthedocs.io/',
         'Changelog': 'https://signifypy.readthedocs.io/en/latest/changelog.html',
         'Issue Tracker': 'https://github.com/WebOfTrust/signifypy/issues',
+        'Source': 'https://github.com/WebOfTrust/signifypy',
     },
     keywords=[
-        # eg: 'keyword1', 'keyword2', 'keyword3',
+        "signing at the eddge",
+        "signify",
+        "secure attribution",
+        "authentic data",
+        "discovery",
+        "resolver"
     ],
-    python_requires='>=3.12.2',
+    python_requires='>=3.12.6',
     install_requires=[
-        'keri>=1.2.0-dev0',
-        'multicommand>=1.0.0',
-        'requests>=2.28',
-        'http_sfv>=0.9.8',
-        'msgpack>=1.0.4',
-        'cbor2>=5.4.3',
+        'keri==1.2.3',
+        'multicommand==1.0.0',
+        'requests==2.32.3',
+        'http_sfv==0.9.9',
+        'msgpack==1.1.0',
+        'cbor2>=5.6.5',
         'sseclient>=0.0.27'
     ],
     extras_require={
+        'test': [
+                'responses>=0.25.6',
+                'coverage>=7.6.10',
+                'pytest>=8.3.4',
+                'mockito==1.5.3'
+        ],
+        'setup': [
+            'setuptools==75.8.0'
+        ]
     },
     tests_require=[
-        'responses>=0.22.0',
-        'coverage>=6.5.0',
-        'pytest>=7.2.0',
-        'mockito==1.4.0'
+        'responses>=0.25.6',
+        'coverage>=7.6.10',
+        'pytest>=8.3.4',
+        'mockito==1.5.3'
     ],
     setup_requires=[
+        'setuptools==75.8.0'
     ],
     entry_points={
         'console_scripts': [

--- a/src/signify/__init__.py
+++ b/src/signify/__init__.py
@@ -3,5 +3,5 @@
 main package
 """
 
-__version__ = '0.1.1'  # also change in setup.py
+__version__ = '0.1.2'  # also change in setup.py
 

--- a/src/signify/app/aiding.py
+++ b/src/signify/app/aiding.py
@@ -51,9 +51,9 @@ class Identifiers:
         data = [data] if data is not None else []
         cnfg = []
         if estOnly:
-            cnfg.append(eventing.TraitCodex.EstOnly)
+            cnfg.append(kering.TraitCodex.EstOnly)
         if DnD:
-            cnfg.append(eventing.TraitCodex.DoNotDelegate)
+            cnfg.append(kering.TraitCodex.DoNotDelegate)
 
         if delpre is not None:
             serder = eventing.delcept(delpre=delpre,

--- a/src/signify/app/cli/commands/status.py
+++ b/src/signify/app/cli/commands/status.py
@@ -7,8 +7,8 @@ keri.kli.commands module
 import argparse
 import sys
 
-from hio import help
 from hio.base import doing
+from keri import help
 from keri.app.cli.common import terming
 from keri.core.coring import Tiers
 

--- a/src/signify/app/cli/sigpy.py
+++ b/src/signify/app/cli/sigpy.py
@@ -5,8 +5,8 @@ keri.kli.commands module
 """
 import multicommand
 from keri import help
-
 from keri.app import directing
+
 from signify.app.cli import commands
 
 logger = help.ogler.getLogger()

--- a/src/signify/app/credentialing.py
+++ b/src/signify/app/credentialing.py
@@ -6,7 +6,7 @@ signify.app.credentialing module
 """
 from collections import namedtuple
 
-from keri.core import coring
+from keri.core import coring, counting
 from keri.core.eventing import TraitDex, interact
 from keri.help import helping
 from keri.vc import proving
@@ -87,7 +87,7 @@ class Registries:
         seqner = coring.Seqner(sn=anc.sn)
         couple = seqner.qb64b + anc.said.encode("utf-8")
         atc = bytearray()
-        atc.extend(coring.Counter(code=coring.CtrDex.SealSourceCouples,
+        atc.extend(counting.Counter(code=counting.CtrDex_1_0.SealSourceCouples,
                                   count=1).qb64b)
         atc.extend(couple)
 
@@ -95,7 +95,7 @@ class Registries:
         if len(atc) % 4:
             raise ValueError("Invalid attachments size={}, nonintegral"
                              " quadlets.".format(len(atc)))
-        pcnt = coring.Counter(code=coring.CtrDex.AttachmentGroup,
+        pcnt = counting.Counter(code=counting.CtrDex_1_0.AttachmentGroup,
                               count=(len(atc) // 4)).qb64b
         msg = bytearray(serder.raw)
         msg.extend(pcnt)

--- a/src/signify/core/keeping.py
+++ b/src/signify/core/keeping.py
@@ -10,7 +10,7 @@ import importlib
 
 from keri import kering
 from keri.app import keeping
-from keri.core import coring
+from keri.core import coring, signing
 from keri.core.coring import Tiers, MtrDex
 
 
@@ -161,8 +161,8 @@ class SaltyKeeper(BaseKeeper):
         # Salter is the entered passcode and used for enc/dec of salts for each AID
         signer = salter.signer(transferable=False)
         self.aeid = signer.verfer.qb64
-        self.encrypter = coring.Encrypter(verkey=self.aeid)
-        self.decrypter = coring.Decrypter(seed=signer.qb64)
+        self.encrypter = signing.Encrypter(verkey=self.aeid)
+        self.decrypter = signing.Decrypter(seed=signer.qb64)
 
         self.tier = tier
         self.icodes = icodes
@@ -177,13 +177,13 @@ class SaltyKeeper(BaseKeeper):
         if bran is not None:
             bran = coring.MtrDex.Salt_128 + 'A' + bran[:21]
             self.creator = keeping.SaltyCreator(salt=bran, stem=stem, tier=tier)
-            self.sxlt = self.encrypter.encrypt(self.creator.salt).qb64
+            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt).qb64
         elif sxlt is None:
             self.creator = keeping.SaltyCreator(stem=stem, tier=tier)
-            self.sxlt = self.encrypter.encrypt(self.creator.salt).qb64
+            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt).qb64
         else:
             self.sxlt = sxlt
-            ciph = coring.Cipher(qb64=self.sxlt)
+            ciph = signing.Cipher(qb64=self.sxlt)
             self.creator = keeping.SaltyCreator(self.decrypter.decrypt(cipher=ciph).qb64, stem=stem, tier=tier)
 
     def params(self):
@@ -279,8 +279,8 @@ class RandyKeeper(BaseKeeper):
 
         signer = salter.signer(transferable=False)
         self.aeid = signer.verfer.qb64
-        self.encrypter = coring.Encrypter(verkey=self.aeid)
-        self.decrypter = coring.Decrypter(seed=signer.qb64)
+        self.encrypter = signing.Encrypter(verkey=self.aeid)
+        self.decrypter = signing.Decrypter(seed=signer.qb64)
 
         self.prxs = prxs
         self.nxts = nxts
@@ -302,30 +302,30 @@ class RandyKeeper(BaseKeeper):
     def incept(self, transferable):
         self.transferable = transferable
         signers = self.creator.create(codes=self.icodes, transferable=transferable)
-        self.prxs = [self.encrypter.encrypt(matter=signer).qb64 for signer in signers]
+        self.prxs = [self.encrypter.encrypt(prim=signer).qb64 for signer in signers]
 
         verfers = [signer.verfer.qb64 for signer in signers]
 
         nsigners = self.creator.create(codes=self.ncodes, transferable=transferable)
-        self.nxts = [self.encrypter.encrypt(matter=signer).qb64 for signer in nsigners]
+        self.nxts = [self.encrypter.encrypt(prim=signer).qb64 for signer in nsigners]
         digers = [coring.Diger(ser=nsigner.verfer.qb64b, code=self.dcode).qb64 for nsigner in nsigners]
         return verfers, digers
 
     def rotate(self, ncodes, transferable, **_):
         self.transferable = transferable
         self.prxs = self.nxts
-        signers = [self.decrypter.decrypt(cipher=coring.Cipher(qb64=nxt),
+        signers = [self.decrypter.decrypt(cipher=signing.Cipher(qb64=nxt),
                                           transferable=self.transferable) for nxt in self.nxts]
         verfers = [signer.verfer.qb64 for signer in signers]
 
         nsigners = self.creator.create(codes=ncodes, transferable=transferable)
-        self.nxts = [self.encrypter.encrypt(matter=signer).qb64 for signer in nsigners]
+        self.nxts = [self.encrypter.encrypt(prim=signer).qb64 for signer in nsigners]
         digers = [coring.Diger(ser=nsigner.verfer.qb64b, code=self.dcode).qb64 for nsigner in nsigners]
 
         return verfers, digers
 
     def sign(self, ser, indexed=True, indices=None, ondices=None, **_):
-        signers = [self.decrypter.decrypt(ser=coring.Cipher(qb64=prx).qb64b, transferable=self.transferable)
+        signers = [self.decrypter.decrypt(ser=signing.Cipher(qb64=prx).qb64b, transferable=self.transferable)
                    for prx in self.prxs]
         return self.__sign__(ser, signers=signers, indexed=indexed, indices=indices, ondices=ondices)
 

--- a/src/signify/signifying.py
+++ b/src/signify/signifying.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass
 
 
 @dataclass
-class State:
+class SignifyState:
+    """
+    Initialization state for a SignifyClient instance
+    """
     controller: dict = None
     agent : dict = None
     ridx: int = None

--- a/tests/app/test_clienting.py
+++ b/tests/app/test_clienting.py
@@ -6,8 +6,9 @@ signify.app.test_clienting module
 Testing clienting with unit tests
 """
 
-from mockito import mock, patch, unstub, verify, verifyNoUnwantedInteractions, expect
 import pytest
+from mockito import mock, patch, unstub, verify, verifyNoUnwantedInteractions, expect, ANY
+
 
 def test_signify_client_defaults():
     from signify.app.clienting import SignifyClient
@@ -52,8 +53,8 @@ def test_signify_client_connect_no_delegation():
     mock_session = mock(spec=requests.Session, strict=True)
     expect(requests, times=1).Session().thenReturn(mock_session)
 
-    from signify.signifying import State
-    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=State, strict=True)
+    from signify.signifying import SignifyState
+    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=SignifyState, strict=True)
     expect(client, times=1).states().thenReturn(mock_state)
 
     from signify.core import authing
@@ -62,8 +63,8 @@ def test_signify_client_connect_no_delegation():
 
     from keri.core import serdering
     mock_serder = mock({'sn': 1}, spec=serdering.Serder, strict=True)
-    from keri.core import coring
-    mock_salter = mock(spec=coring.Salter, strict=True)
+    from keri.core import signing
+    mock_salter = mock(spec=signing.Salter, strict=True)
     mock_controller = mock({'pre': 'a prefix', 'salter': mock_salter, 'serder': mock_serder}, spec=authing.Controller, strict=True)
     expect(authing, times=1).Controller(bran='abcdefghijklmnop01234', tier=Tiers.low, state=mock_state.controller).thenReturn(mock_controller)
     
@@ -73,7 +74,7 @@ def test_signify_client_connect_no_delegation():
 
     from signify.core import authing
     mock_authenticator = mock({'verify': lambda: {'hook1': 'hook1 info', 'hook2': 'hook2 info'}}, spec=authing.Authenticater, strict=True)
-    expect(authing, times=1).Authenticater(agent=mock_agent, ctrl=mock_controller).thenReturn(mock_authenticator)
+    expect(authing, times=1).Authenticater(agent=mock_agent, ctrl=ANY).thenReturn(mock_authenticator)
 
     from signify.app import clienting
     mock_signify_auth = mock(spec=clienting.SignifyAuth, strict=True)
@@ -89,6 +90,7 @@ def test_signify_client_connect_no_delegation():
     unstub()
 
 def test_signify_client_connect_delegation():
+    # setup for client init
     from signify.core import authing
     from keri.core.coring import Tiers
     mock_init_controller = mock(spec=authing.Controller, strict=True)
@@ -97,12 +99,13 @@ def test_signify_client_connect_delegation():
     from signify.app.clienting import SignifyClient
     client = SignifyClient(passcode='abcdefghijklmnop01234')
 
+    # setup for client.connect()
     import requests
     mock_session = mock(spec=requests.Session, strict=True)
     expect(requests, times=1).Session().thenReturn(mock_session)
 
-    from signify.signifying import State
-    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=State, strict=True)
+    from signify.signifying import SignifyState
+    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=SignifyState, strict=True)
     expect(client, times=1).states().thenReturn(mock_state)
 
     from signify.core import authing
@@ -111,9 +114,10 @@ def test_signify_client_connect_delegation():
 
     from keri.core import serdering
     mock_serder = mock({'sn': 0}, spec=serdering.Serder, strict=True)
-    from keri.core import coring
-    mock_salter = mock(spec=coring.Salter, strict=True)
+    from keri.core import signing
+    mock_salter = mock(spec=signing.Salter, strict=True)
     mock_controller = mock({'pre': 'a prefix', 'salter': mock_salter, 'serder': mock_serder}, spec=authing.Controller, strict=True)
+    # when(authing.Controller).thenReturn(mock_controller)
     expect(authing, times=1).Controller(bran='abcdefghijklmnop01234', tier=Tiers.low, state=mock_state.controller).thenReturn(mock_controller)
     
     from signify.core import keeping
@@ -124,7 +128,7 @@ def test_signify_client_connect_delegation():
 
     from signify.core import authing
     mock_authenticator = mock({'verify': lambda: {'hook1': 'hook1 info', 'hook2': 'hook2 info'}}, spec=authing.Authenticater, strict=True)
-    expect(authing, times=1).Authenticater(agent=mock_agent, ctrl=mock_controller).thenReturn(mock_authenticator)
+    expect(authing, times=1).Authenticater(agent=mock_agent, ctrl=ANY).thenReturn(mock_authenticator)
 
     from signify.app import clienting
     mock_signify_auth = mock(spec=clienting.SignifyAuth, strict=True)
@@ -156,8 +160,8 @@ def test_signify_client_connect_bad_delegation():
     mock_session = mock(spec=requests.Session, strict=True)
     expect(requests, times=1).Session().thenReturn(mock_session)
 
-    from signify.signifying import State
-    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=State, strict=True)
+    from signify.signifying import SignifyState
+    mock_state = mock({'pidx': 0, 'agent': 'agent info', 'controller': 'controller info'}, spec=SignifyState, strict=True)
     expect(client, times=1).states().thenReturn(mock_state)
 
     from signify.core import authing
@@ -166,8 +170,8 @@ def test_signify_client_connect_bad_delegation():
 
     from keri.core import serdering
     mock_serder = mock({'sn': 1}, spec=serdering.Serder, strict=True)
-    from keri.core import coring
-    mock_salter = mock(spec=coring.Salter, strict=True)
+    from keri.core import signing
+    mock_salter = mock(spec=signing.Salter, strict=True)
     mock_controller = mock({'pre': 'a different prefix', 'salter': mock_salter, 'serder': mock_serder}, spec=authing.Controller, strict=True)
     expect(authing, times=1).Controller(bran='abcdefghijklmnop01234', tier=Tiers.low, state=mock_state.controller).thenReturn(mock_controller)
     
@@ -230,8 +234,8 @@ def test_signify_client_properties():
     from keri.core import serdering
     mock_serder = mock(spec=serdering.Serder, strict=True)
 
-    from keri.core import coring
-    mock_salter = mock(spec=coring.Salter, strict=True)
+    from keri.core import signing
+    mock_salter = mock(spec=signing.Salter, strict=True)
 
     from signify.core import authing
     from keri.core.coring import Tiers
@@ -451,7 +455,6 @@ def test_signify_client_delete():
     client.session = mock_session # type: ignore
 
     mock_response = mock({'ok': True}, spec=requests.Response, strict=True)
-    from mockito import kwargs
     expect(mock_session).delete('http://example.com/my_path', params={'a': 'param'}, headers={'a': 'header'}).thenReturn(mock_response)
 
     out = client.delete('my_path', params={'a': 'param'}, headers={'a': 'header'})

--- a/tests/app/test_credentialing.py
+++ b/tests/app/test_credentialing.py
@@ -5,9 +5,9 @@ signify.app.test_credentialing module
 
 Testing credentialing with unit tests
 """
+from keri.core import eventing, coring
 from keri.peer import exchanging
 from keri.vdr import eventing as veventing
-from keri.core import eventing, coring
 from mockito import mock, unstub, verify, verifyNoUnwantedInteractions, expect, ANY
 
 from signify.app import credentialing

--- a/tests/app/test_ending.py
+++ b/tests/app/test_ending.py
@@ -6,8 +6,9 @@ signify.app.test_ending module
 Testing ending with unit tests
 """
 
-from mockito import mock, unstub, verifyNoUnwantedInteractions, expect
 import pytest
+from mockito import mock, unstub, verifyNoUnwantedInteractions, expect
+
 
 def test_end_role_authorizations_name():
     from signify.app.clienting import SignifyClient

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -6,8 +6,7 @@ signify.app.test_grouping module
 Testing grouping with unit tests
 """
 
-import pytest
-from mockito import mock, verify, verifyNoUnwantedInteractions, unstub, expect
+from mockito import mock, verifyNoUnwantedInteractions, unstub, expect
 
 
 def test_grouping_get_request():

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -6,12 +6,12 @@ signify.app.test_authing module
 Testing authing with unit tests
 """
 
+import pytest
 from keri import kering
 from keri.core import serdering
 from keri.core.coring import Tiers
-from keri.kering import Serials, versify
+from keri.kering import Kinds, versify
 from mockito import mock, unstub, expect, verifyNoUnwantedInteractions
-import pytest
 
 
 def rt(a, b, c):
@@ -95,13 +95,13 @@ def test_controller(bran):
 
     assert ctrl.tier == Tiers.low
 
-    from keri.core import coring
-    assert type(ctrl.salter) is coring.Salter
-    assert type(ctrl.signer) is coring.Signer
+    from keri.core import signing
+    assert type(ctrl.salter) is signing.Salter
+    assert type(ctrl.signer) is signing.Signer
     assert ctrl.signer.code == "A"
     assert ctrl.signer.qb64 == "AF1iHYsl-7DZFD71kcsg5iUAkLP3Lh_01RZFEHhL3629"
 
-    assert type(ctrl.nsigner) is coring.Signer
+    assert type(ctrl.nsigner) is signing.Signer
     assert ctrl.nsigner.code == "A"
     assert ctrl.nsigner.qb64 == "AGG0prnUWeKJGfh00-rrSqBIxR0Mx5K1FP0XC_UtCdjX"
 
@@ -132,7 +132,7 @@ def test_controller_derive():
     assert serder.raw == raw
 
     from keri.core import coring
-    e1 = dict(v=versify(kind=Serials.json, size=0),
+    e1 = dict(v=versify(kind=Kinds.json, size=0),
               t="rot",
               d="",
               i="EMPYj-h2OoCyPGQoUUd1tLUYe62YD_8A3jjXxqYawLcV",
@@ -150,8 +150,8 @@ def test_controller_derive():
     
     _, e1 = coring.Saider.saidify(sad=e1)
 
-    from signify.signifying import State
-    state = State(controller={"ee": e1})
+    from signify.signifying import SignifyState
+    state = SignifyState(controller={"ee": e1})
     serder = ctrl.derive(state=state)
 
     assert serder.raw == (b'{"v":"KERI10JSON000160_","t":"rot","d":"ENvjVqUoq2SGDrFSzqI5AI37ZE4IAlKLdFGw'
@@ -269,7 +269,7 @@ def test_controller_rotate_salty():
 #     from signify.core.authing import Controller
 #     ctrl = Controller(bran="abcdefghijklmnop01234", tier=Tiers.low)
 
-#     from keri.core.coring import Salter
+#     from keri.core.signing import Salter
 #     mock_salter = mock({'qb64': 'salter qb64'}, spec=Salter, strict=True)
 #     ctrl.salter = mock_salter
 
@@ -278,7 +278,7 @@ def test_controller_rotate_salty():
 #     from signify.core import keeping
 #     when(keeping).SaltyCreator(salt='salter qb64', stem='signify:controller', tier=Tiers.low).thenReturn(mock_creator)
 
-#     from keri.core.coring import Signer
+#     from keri.core.signing import Signer
 #     mock_signer = mock(spec=Signer, strict=True)
 #     ctrl.signer = mock_signer
 #     mock_nsigner = mock(spec=Signer, strict=True)

--- a/tests/core/test_keeping.py
+++ b/tests/core/test_keeping.py
@@ -6,11 +6,12 @@ signify.core.keeping module
 Testing authentication
 """
 
-from mockito import mock, verifyNoUnwantedInteractions, unstub, expect
 import pytest
+from mockito import mock, verifyNoUnwantedInteractions, unstub, expect
+
 
 def test_keeping_manager():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -23,7 +24,7 @@ def test_keeping_manager():
     unstub()
 
 def test_keeping_manager_new_salty():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -41,7 +42,7 @@ def test_keeping_manager_new_salty():
     unstub()
 
 def test_keeping_manager_new_randy():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -59,7 +60,7 @@ def test_keeping_manager_new_randy():
     unstub()
 
 def test_keeping_manager_new_group():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -77,7 +78,7 @@ def test_keeping_manager_new_group():
     unstub()
 
 def test_keeping_manager_new_extern():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -97,7 +98,7 @@ def test_keeping_manager_new_extern():
     unstub()
 
 def test_keeping_manager_new_extern_unknown():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -114,7 +115,7 @@ def test_keeping_manager_new_extern_unknown():
     unstub()
 
 def test_keeping_manager_get_salty():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -138,7 +139,7 @@ def test_keeping_manager_get_salty():
     unstub()
 
 def test_keeping_manager_get_salty_pidx():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -158,7 +159,7 @@ def test_keeping_manager_get_salty_pidx():
     unstub()
 
 def test_keeping_manager_get_randy():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -182,7 +183,7 @@ def test_keeping_manager_get_randy():
     unstub()
 
 def test_keeping_manager_get_group():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -207,33 +208,33 @@ def test_keeping_manager_get_group():
 
 def test_salty_keeper():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
-    
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
-    
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from keri.app.keeping import SaltyCreator
     mock_creator = mock({'salt': 'creator salt'}, spec=SaltyCreator, strict=True)
     from keri.app import keeping
     expect(keeping, times=1).SaltyCreator(stem='signify:aid', tier='low').thenReturn(mock_creator)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt('creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
 
     # test
     from signify.core.keeping import SaltyKeeper
@@ -249,24 +250,24 @@ def test_salty_keeper():
 
 def test_salty_keeper_bran():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from keri.app.keeping import SaltyCreator
     mock_creator = mock({'salt': 'creator salt'}, spec=SaltyCreator, strict=True)
@@ -274,9 +275,9 @@ def test_salty_keeper_bran():
     from keri.app import keeping
     expect(keeping, times=1).SaltyCreator(salt='0AA0123456789abcdefghijk', stem='signify:aid', tier='low').thenReturn(mock_creator)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt('creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
 
     # test
     from signify.core.keeping import SaltyKeeper
@@ -289,30 +290,30 @@ def test_salty_keeper_bran():
 
 def test_salty_keeper_sxlt():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock({'qb64': 'salter qb64'}, spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
 
-    from keri.core import coring
-    expect(coring, times=1).Cipher(qb64='0123456789abcdefghijk').thenReturn(mock_cipher)
+    from keri.core import signing
+    expect(signing, times=1).Cipher(qb64='0123456789abcdefghijk').thenReturn(mock_cipher)
 
     expect(mock_decrypter, times=1).decrypt(cipher=mock_cipher).thenReturn(mock_salter)
 
@@ -333,24 +334,24 @@ def test_salty_keeper_sxlt():
 
 def test_salty_keeper_incept():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from keri.app.keeping import SaltyCreator
     mock_creator = mock({'salt': 'creator salt'}, spec=SaltyCreator, strict=True)
@@ -358,9 +359,9 @@ def test_salty_keeper_incept():
     from keri.app import keeping
     expect(keeping, times=1).SaltyCreator(stem='signify:aid', tier='low').thenReturn(mock_creator)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt('creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
 
     # incept mocks
     mock_incept_verfer = mock({'qb64': 'incept verfer qb64'}, spec=Verfer, strict=True)
@@ -372,6 +373,7 @@ def test_salty_keeper_incept():
     expect(mock_creator, times=1).create(codes=['A'], pidx=0, kidx=1, transferable=True).thenReturn([mock_incept_nsigner])
 
     from keri.core.coring import Diger
+    from keri.core import coring
     mock_diger = mock({'qb64': 'diger qb64'}, spec=Diger, strict=True)
     expect(coring, times=1).Diger(ser=b'incept nverfer qb64b', code='E').thenReturn(mock_diger)
 
@@ -388,24 +390,24 @@ def test_salty_keeper_incept():
 
 def test_salty_keeper_rotate():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from keri.app.keeping import SaltyCreator
     mock_creator = mock({'salt': 'creator salt'}, spec=SaltyCreator, strict=True)
@@ -413,9 +415,9 @@ def test_salty_keeper_rotate():
     from keri.app import keeping
     expect(keeping, times=1).SaltyCreator(stem='signify:aid', tier='low').thenReturn(mock_creator)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt('creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
 
     # rotate mocks
     mock_rotate_verfer = mock({'qb64': 'rotate verfer qb64'}, spec=Verfer, strict=True)
@@ -427,6 +429,7 @@ def test_salty_keeper_rotate():
     expect(mock_creator, times=1).create(codes=['A'], pidx=0, kidx=2, transferable=True).thenReturn([mock_rotate_nsigner])
 
     from keri.core.coring import Diger
+    from keri.core import coring
     mock_diger = mock({'qb64': 'rotate diger qb64'}, spec=Diger, strict=True)
     expect(coring, times=1).Diger(ser=b'rotate nverfer qb64b', code='E').thenReturn(mock_diger)
 
@@ -445,24 +448,24 @@ def test_salty_keeper_rotate():
 
 def test_salty_keeper_sign():
     # salty keep init mocks
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from keri.app.keeping import SaltyCreator
     mock_creator = mock({'salt': 'creator salt'}, spec=SaltyCreator, strict=True)
@@ -470,9 +473,9 @@ def test_salty_keeper_sign():
     from keri.app import keeping
     expect(keeping, times=1).SaltyCreator(stem='signify:aid', tier='low').thenReturn(mock_creator)
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt('creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
 
     # sign mock
     expect(mock_creator, times=1).create(codes=['A'], pidx=0, kidx=0, transferable=False).thenReturn([mock_signer])
@@ -492,24 +495,24 @@ def test_salty_keeper_sign():
     unstub()
 
 def test_randy_keeper():
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from signify.core.keeping import RandyKeeper
     rk = RandyKeeper(mock_salter)
@@ -527,24 +530,24 @@ def test_randy_keeper():
     unstub()
     
 def test_randy_keeper_params():
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     from signify.core.keeping import RandyKeeper
     rk = RandyKeeper(mock_salter, transferable=True, nxts=['nxt1', 'nxt2'], prxs=['prx1', 'prx2'])
@@ -557,46 +560,48 @@ def test_randy_keeper_params():
     unstub()
 
 def test_randy_keeper_incept():
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     # start incept mocks
     from keri.app.keeping import RandyCreator
     mock_creator = mock(spec=RandyCreator, strict=True)
 
     # verfers mocks
-    from keri.core.coring import Signer, Verfer
+    from keri.core.coring import Verfer
+    from keri.core.signing import Signer
     mock_verfer = mock({'qb64': 'signer verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer}, spec=Signer, strict=True)
     expect(mock_creator, times=1).create(codes=['A'], transferable=True).thenReturn([mock_signer])
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(matter=mock_signer).thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(prim=mock_signer).thenReturn(mock_cipher)
 
     # digers mocks
     mock_verfer = mock({'qb64b': b'signer verfer qb64b'}, spec=Verfer, strict=True)
     mock_nsigner = mock({'verfer': mock_verfer}, spec=Signer, strict=True)
     expect(mock_creator, times=1).create(codes=['B'], transferable=True).thenReturn([mock_nsigner])
-    expect(mock_encrypter, times=1).encrypt(matter=mock_nsigner).thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(prim=mock_nsigner).thenReturn(mock_cipher)
 
     from keri.core.coring import Diger
+    from keri.core import coring
     mock_diger = mock({'qb64': 'diger qb64'}, spec=Diger, strict=True)
     expect(coring, times=1).Diger(ser=b'signer verfer qb64b', code='E').thenReturn(mock_diger)
     
@@ -614,36 +619,37 @@ def test_randy_keeper_incept():
     unstub()
 
 def test_randy_keeper_rotate():
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
     # start rotate mocks
     from keri.app.keeping import RandyCreator
     mock_creator = mock(spec=RandyCreator, strict=True)
 
     from keri.core import coring
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_nxt_cipher = mock(spec=Cipher, strict=True)
-    expect(coring, times=1).Cipher(qb64='nxt qb64').thenReturn(mock_nxt_cipher)
+    expect(signing, times=1).Cipher(qb64='nxt qb64').thenReturn(mock_nxt_cipher)
 
     # verfers mocks
-    from keri.core.coring import Signer, Verfer
+    from keri.core.coring import Verfer
+    from keri.core.signing import Signer
     mock_verfer = mock({'qb64': 'signer verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer}, spec=Signer, strict=True)
     expect(mock_decrypter, times=1).decrypt(cipher=mock_nxt_cipher, transferable=True).thenReturn(mock_signer)
@@ -653,9 +659,9 @@ def test_randy_keeper_rotate():
     mock_nsigner = mock({'verfer': mock_verfer}, spec=Signer, strict=True)
     expect(mock_creator, times=1).create(codes=['A'], transferable=True).thenReturn([mock_nsigner])
 
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(matter=mock_nsigner).thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(prim=mock_nsigner).thenReturn(mock_cipher)
 
     from keri.core.coring import Diger
     mock_diger = mock({'qb64': 'diger qb64'}, spec=Diger, strict=True)
@@ -675,31 +681,31 @@ def test_randy_keeper_rotate():
     unstub()
 
 def test_randy_keeper_sign():
-    from keri.core.coring import Salter, Signer
+    from keri.core.signing import Salter, Signer
     mock_salter = mock(spec=Salter, strict=True)
     from keri.core.coring import Verfer
     mock_verfer = mock({'qb64': 'verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer ,'qb64': 'signer qb64'}, spec=Signer, strict=True)
     expect(mock_salter, times=1).signer(transferable=False).thenReturn(mock_signer)
 
-    from keri.core.coring import Encrypter
+    from keri.core.signing import Encrypter
     mock_encrypter = mock(spec=Encrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
+    from keri.core import signing
+    expect(signing, times=1).Encrypter(verkey='verfer qb64').thenReturn(mock_encrypter)
 
-    from keri.core.coring import Decrypter
+    from keri.core.signing import Decrypter
     mock_decrypter= mock(spec=Decrypter, strict=True)
     
-    from keri.core import coring
-    expect(coring, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
+    from keri.core import signing
+    expect(signing, times=1).Decrypter(seed='signer qb64').thenReturn(mock_decrypter)
 
-    from keri.core import coring
-    from keri.core.coring import Cipher
+    from keri.core.signing import Cipher
     mock_prx_cipher = mock({'qb64b': b'cipher qb64b'}, spec=Cipher, strict=True)
-    expect(coring, times=1).Cipher(qb64='prx qb64').thenReturn(mock_prx_cipher)
+    expect(signing, times=1).Cipher(qb64='prx qb64').thenReturn(mock_prx_cipher)
 
-    from keri.core.coring import Signer, Verfer
+    from keri.core.coring import Verfer
+    from keri.core.signing import Signer
     mock_verfer = mock({'qb64': 'signer verfer qb64'}, spec=Verfer, strict=True)
     mock_signer = mock({'verfer': mock_verfer}, spec=Signer, strict=True)
     expect(mock_decrypter, times=1).decrypt(ser=b'cipher qb64b', transferable=False).thenReturn(mock_signer)
@@ -719,7 +725,7 @@ def test_randy_keeper_sign():
     unstub()
 
 def test_group_keeper():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -736,7 +742,7 @@ def test_group_keeper():
     assert gk.algo == Algos.group
 
 def test_group_keeper_incept():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -754,7 +760,7 @@ def test_group_keeper_incept():
     unstub()
 
 def test_group_keeper_rotate():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -772,7 +778,7 @@ def test_group_keeper_rotate():
     unstub()
 
 def test_group_keeper_sign():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -781,7 +787,6 @@ def test_group_keeper_sign():
     from signify.core.keeping import GroupKeeper
     gk = GroupKeeper(mgr=mock_manager, mhab={'state': {'k': ['key 1'], 'n': ['n dig 1']}}, keys=['key 1'], ndigs=['n dig 1'])
 
-    from signify.core.keeping import BaseKeeper
     mock_keeper = mock(strict=True)
     expect(mock_manager, times=1).get({'state': {'k': ['key 1'], 'n': ['n dig 1']}}).thenReturn(mock_keeper)
 
@@ -795,7 +800,7 @@ def test_group_keeper_sign():
     unstub()
 
 def test_group_keeper_params():
-    from keri.core.coring import Salter
+    from keri.core.signing import Salter
     mock_salter = mock(spec=Salter, strict=True)
 
     from signify.core.keeping import Manager
@@ -824,7 +829,7 @@ def test_extern_keeper():
 def test_base_keeper_sign():
     from signify.core.keeping import BaseKeeper
     
-    from keri.core.coring import Signer
+    from keri.core.signing import Signer
     mock_signer = mock(spec=Signer, strict=True)
 
     from keri.core.coring import Cigar
@@ -842,7 +847,7 @@ def test_base_keeper_sign():
 def test_base_keeper_sign_indexed(indexed, indices, ondices):
     from signify.core.keeping import BaseKeeper
     
-    from keri.core.coring import Signer
+    from keri.core.signing import Signer
     mock_signer_one = mock(spec=Signer, strict=True)
 
     from keri.core import Siger
@@ -860,7 +865,7 @@ def test_base_keeper_sign_indexed(indexed, indices, ondices):
 def test_base_keeper_sign_indexed_boom(indexed, indices, ondices, expected):
     from signify.core.keeping import BaseKeeper
     
-    from keri.core.coring import Signer
+    from keri.core.signing import Signer
     mock_signer_one = mock(spec=Signer, strict=True)
 
     with pytest.raises(ValueError, match=expected):

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -30,10 +30,12 @@ def test_exchanges_send(mockHelpingNowIso8601):
     expect(mock_response, times=1).json().thenReturn({'content': 'things I found'})
     expect(mock_client, times=1).post("/identifiers/aid1/exchanges",
                                       json={'tpc': 'credentals',
-                                            'exn': {'v': 'KERI10JSON0000c2_', 't': 'exn',
+                                            'exn': {'v': 'KERI10JSON0000ca_', 't': 'exn',
                                                     'd':
-                                                        'EAUlN3BbKZMrkGXEAw_nNppDC-ziimwxgPJfewodW_dh',
-                                                    'i': 'a_prefix', 'p': '',
+                                                        'EE1dCWxjov6vKtKue_700dmS7sn8dOjhTSiNuEsfuREh',
+                                                    'i': 'a_prefix',
+                                                    'rp':'',
+                                                    'p': '',
                                                     'dt': '2021-06-27T21:26:21.233257+00:00',
                                                     'r': '/ipex/admit', 'q': {}, 'a': {'a': 'b'},
                                                     'e': {}}, 'sigs': ['a signature'], 'atc': '',
@@ -45,7 +47,7 @@ def test_exchanges_send(mockHelpingNowIso8601):
                                                         payload=payload,
                                                         embeds=embeds, recipients=recipients)  # type: ignore
 
-    assert exn.said == "EAUlN3BbKZMrkGXEAw_nNppDC-ziimwxgPJfewodW_dh"
+    assert exn.said == "EE1dCWxjov6vKtKue_700dmS7sn8dOjhTSiNuEsfuREh"
     assert sigs == ['a signature']
     assert out == {'content': 'things I found'}
 


### PR DESCRIPTION
Starts the upgrade to KERIpy 1.2.3. Some of the test mocks were overly aggressive with mockito matching strictness so they were changed to `ANY` in places where it doesn't matter to have an `ANY`.

The exchange message test needed to be updated to have the `rp` field added.

A bunch of `Encrypter.encrypt` invocations needed to change from positional arguments to use the `ser=` or `matter=` keyword arguments.