### PR TITLE
fix: default salt encoding to 1AAH like signify-ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # vscode specific
 .vscode
+
+# temp files
+.tmp

--- a/src/signify/core/authing.py
+++ b/src/signify/core/authing.py
@@ -122,6 +122,27 @@ class Controller:
         self.serder = eventing.interact(pre=self.serder.pre, dig=self.serder.said, sn=self.serder.sn + 1, data=[anchor])
         return self.serder, [self.signer.sign(self.serder.raw, index=0).qb64]
 
+    def _decryptSaltQb64(self, decrypter, cipher):
+        """
+        Support decrypting both Salter and Streamer codes
+        Salter are fixed size, 1AAH class salts and variable size are Streamer 4C class codes.
+
+        Returns:
+            salt as qualified base 64 whether a Salter or Streamer primitive
+        """
+        plain = decrypter.decrypt(cipher=cipher, bare=True)
+        qb64 = plain.decode("utf-8") if hasattr(plain, "decode") else plain
+
+        try:
+            salter = signing.Salter(qb64=qb64)
+        except Exception as ex:
+            raise kering.ValidationError("decrypted sxlt is not a Salt_128") from ex
+
+        if salter.qb64 != qb64:
+            raise kering.ValidationError("decrypted sxlt must contain exactly one Salt_128")
+
+        return qb64
+
     def rotate(self, nbran, aids):
         """
         Rotate passcode involves re-encrypting all saved AID salts for salty keyed AIDs and
@@ -186,7 +207,8 @@ class Controller:
         decrypter = signing.Decrypter(seed=nsigner.qb64)  # decrypter with old salt
 
         # First encrypt and save old Salt in case we need a recovery
-        sxlt = encrypter.encrypt(prim=coring.Matter(qb64b=self.bran)).qb64
+        sxlt = encrypter.encrypt(prim=coring.Matter(qb64b=self.bran),
+                                 code=coring.MtrDex.X25519_Cipher_Salt).qb64
 
         data = dict(
             rot=rot.ked,
@@ -201,7 +223,7 @@ class Controller:
             if "salty" in aid:
                 salty = aid["salty"]
                 cipher = signing.Cipher(qb64=salty["sxlt"])
-                dnxt = decrypter.decrypt(cipher=cipher).qb64
+                dnxt = self._decryptSaltQb64(decrypter, cipher)
 
                 # Now we have the AID salt, use it to verify against the current public keys
                 acreator = keeping.SaltyCreator(dnxt, stem=salty["stem"], tier=salty["tier"])
@@ -211,7 +233,8 @@ class Controller:
                 if pubs != [signer.verfer.qb64 for signer in signers]:
                     raise kering.ValidationError(f"unable to rotate, validation of salt to public keys {pubs} failed")
 
-                asxlt = encrypter.encrypt(prim=coring.Matter(qb64=dnxt)).qb64
+                asxlt = encrypter.encrypt(prim=coring.Matter(qb64=dnxt),
+                                          code=coring.MtrDex.X25519_Cipher_Salt).qb64
                 keys[pre] = dict(
                     sxlt=asxlt
                 )

--- a/src/signify/core/keeping.py
+++ b/src/signify/core/keeping.py
@@ -192,10 +192,12 @@ class SaltyKeeper(BaseKeeper):
         if bran is not None:
             bran = coring.MtrDex.Salt_128 + 'A' + bran[:21]
             self.creator = keeping.SaltyCreator(salt=bran, stem=stem, tier=tier)
-            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt).qb64
+            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt,
+                                               code=coring.MtrDex.X25519_Cipher_Salt).qb64
         elif sxlt is None:
             self.creator = keeping.SaltyCreator(stem=stem, tier=tier)
-            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt).qb64
+            self.sxlt = self.encrypter.encrypt(ser=self.creator.salt,
+                                               code=coring.MtrDex.X25519_Cipher_Salt).qb64
         else:
             self.sxlt = sxlt
             ciph = signing.Cipher(qb64=self.sxlt)

--- a/tests/core/test_authing.py
+++ b/tests/core/test_authing.py
@@ -8,7 +8,7 @@ Testing authing with unit tests
 
 import pytest
 from keri import kering
-from keri.core import serdering
+from keri.core import coring, serdering, signing
 from keri.core.coring import Tiers
 from keri.kering import Kinds, versify
 from mockito import mock, unstub, expect, verifyNoUnwantedInteractions
@@ -248,6 +248,49 @@ def test_controller_rotate_salty():
     assert 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK' in out['keys']
     assert 'sxlt' in out['keys']['ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK'] # type: ignore
     assert out['keys']['ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK']['sxlt'] != "1AAH2R_SPhr_5vIBGGtyVamaGVDQAcYlgmwDOkJwM-q6Qw8K5NT7jLzJ0k6_7sa3oyKK33ym8JX1Il4MoUiy8ixYwsVWYhaU3sMT" # type: ignore
+    assert signing.Cipher(qb64=out["sxlt"]).code == coring.MtrDex.X25519_Cipher_Salt
+    assert signing.Cipher(qb64=out["keys"]["ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK"]["sxlt"]).code == coring.MtrDex.X25519_Cipher_Salt
+
+
+def test_ctlr_rotate_migrates_on_write_4C_to_1AAH_salty_sxlt_cipher():
+    from keri.app import keeping
+    from signify.core.authing import Controller
+
+    ctrl = Controller(bran="abcdefghijklmnop01234", tier=Tiers.low)
+    signer = ctrl.salter.signer(transferable=False)
+    encrypter = signing.Encrypter(verkey=signer.verfer.qb64)
+    aid_salter = signing.Salter(raw=b'fedcba9876543210')
+    creator = keeping.SaltyCreator(salt=aid_salter.qb64, stem="signify:aid", tier=Tiers.low)
+    signers = creator.create(codes=["A"], pidx=0, kidx=0, transferable=False)
+
+    # Cipher starts as 4C due to KERIpy Encrypter.encrypt default.
+    sxlt = encrypter.encrypt(ser=aid_salter.qb64).qb64
+    prefix = "legacy-pre"
+
+    assert signing.Cipher(qb64=sxlt).code == coring.MtrDex.X25519_Cipher_L0
+
+    aid = {
+        "name": "aid1",
+        "prefix": prefix,
+        "salty": {
+            "pidx": 0,
+            "stem": "signify:aid",
+            "sxlt": sxlt,
+            "tier": Tiers.low,
+            "icodes": ["A"],
+            "kidx": 0,
+            "transferable": False,
+        },
+        "state": {
+            "k": [signer.verfer.qb64 for signer in signers],
+        },
+    }
+    # Rotate will read the 4C encoded CESR primitive and migrate it on-write to the 1AAH code
+    # that is compatible with SignifyTS.
+    out = ctrl.rotate(nbran="0123456789abcdefghijk", aids=[aid])
+
+    assert signing.Cipher(qb64=out["sxlt"]).code == coring.MtrDex.X25519_Cipher_Salt
+    assert signing.Cipher(qb64=out["keys"][prefix]["sxlt"]).code == coring.MtrDex.X25519_Cipher_Salt
 
 def test_controller_rotate_randy():
     from signify.core.authing import Controller

--- a/tests/core/test_keeping.py
+++ b/tests/core/test_keeping.py
@@ -7,6 +7,7 @@ Testing authentication
 """
 
 import pytest
+from keri.core import coring as core_coring
 from mockito import mock, verifyNoUnwantedInteractions, unstub, expect, when
 
 
@@ -234,7 +235,9 @@ def test_salty_keeper():
 
     from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(
+        ser='creator salt',
+        code=core_coring.MtrDex.X25519_Cipher_Salt).thenReturn(mock_cipher)
 
     # test
     from signify.core.keeping import SaltyKeeper
@@ -277,7 +280,9 @@ def test_salty_keeper_bran():
 
     from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(
+        ser='creator salt',
+        code=core_coring.MtrDex.X25519_Cipher_Salt).thenReturn(mock_cipher)
 
     # test
     from signify.core.keeping import SaltyKeeper
@@ -287,6 +292,36 @@ def test_salty_keeper_bran():
 
     verifyNoUnwantedInteractions()
     unstub()
+
+
+def test_salty_keeper_bran_sxlt_uses_x25519_cipher_salt():
+    from keri.core import signing
+    from signify.core.keeping import SaltyKeeper
+
+    salter = signing.Salter(raw=b'0123456789abcdef')
+    sk = SaltyKeeper(salter, pidx=0, bran='0123456789abcdefghijk')
+
+    cipher = signing.Cipher(qb64=sk.params()["sxlt"])
+    assert cipher.code == core_coring.MtrDex.X25519_Cipher_Salt
+
+
+def test_salty_keeper_accepts_stream_cipher_salt():
+    from keri.core import signing
+    from signify.core.keeping import SaltyKeeper
+
+    salter = signing.Salter(raw=b'0123456789abcdef')
+    signer = salter.signer(transferable=False)
+    encrypter = signing.Encrypter(verkey=signer.verfer.qb64)
+    aid_salter = signing.Salter(raw=b'fedcba9876543210')
+    sxlt = encrypter.encrypt(ser=aid_salter.qb64).qb64  # an unspecified code defaults to 4C variable size cipher
+
+    assert signing.Cipher(qb64=sxlt).code == core_coring.MtrDex.X25519_Cipher_L0
+
+    sk = SaltyKeeper(salter, pidx=0, sxlt=sxlt)
+
+    assert sk.params()["sxlt"] == sxlt
+    assert sk.creator.salt == aid_salter.qb64
+
 
 def test_salty_keeper_sxlt():
     # salty keep init mocks
@@ -361,7 +396,9 @@ def test_salty_keeper_incept():
 
     from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(
+        ser='creator salt',
+        code=core_coring.MtrDex.X25519_Cipher_Salt).thenReturn(mock_cipher)
 
     # incept mocks
     mock_incept_verfer = mock({'qb64': 'incept verfer qb64'}, spec=Verfer, strict=True)
@@ -417,7 +454,9 @@ def test_salty_keeper_rotate():
 
     from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(
+        ser='creator salt',
+        code=core_coring.MtrDex.X25519_Cipher_Salt).thenReturn(mock_cipher)
 
     # rotate mocks
     mock_rotate_verfer = mock({'qb64': 'rotate verfer qb64'}, spec=Verfer, strict=True)
@@ -475,7 +514,9 @@ def test_salty_keeper_sign():
 
     from keri.core.signing import Cipher
     mock_cipher = mock({'qb64': 'cipher qb64'}, spec=Cipher, strict=True)
-    expect(mock_encrypter, times=1).encrypt(ser='creator salt').thenReturn(mock_cipher)
+    expect(mock_encrypter, times=1).encrypt(
+        ser='creator salt',
+        code=core_coring.MtrDex.X25519_Cipher_Salt).thenReturn(mock_cipher)
 
     # sign mock
     expect(mock_creator, times=1).create(codes=['A'], pidx=0, kidx=0, transferable=False).thenReturn([mock_signer])


### PR DESCRIPTION
My W3C crosswalk work surfaced an interesting bug in SignifyPy regarding salt encryption (SaltyKeeper.params.sxlt).

### Background
SignifyTS was always using 1AAH, the X25519_Cipher_Salt, a fixed size salt cipher, and thusly never had to worry about variable size cipher salts like 4C / X25519_Cipher_L0, a variable X25519 salt cipher. So, the implicit rule for Encrypter.encrypt() in SignifyTS was that everything used 1AAH / X25519_Cipher_Salt by default.

### Problem
Yet SignifyPy had a different default. This is due to KERIpy's default in Encrypter.encrypt() having the default set as so:
```py
class Encrypter(Matter):
    ...
    def encrypt(...):
        ...
        if not code:  # assumes default is sniffable stream
            code = CiXDex.X25519_Cipher_L0
```
which meant that **SignifyPy's default for salt encryption** was `4C`, not `1AAH`. 

I hit this sometime between 11:30 PM and 12:30 AM on Tuesday night of IIW last week trying to get the demo working and since I had not yet figured this out then I just added variable size code support to SignifyTS' Matter._exfil and Matter._infil, which meant a few code table entries got added in including the 4C ..._L0 code X25519_Cipher_L0. This was the wrong solution and I am backing those changes out. The right solution is below.

### Fix 

The fix is simple. Inside of SignifyPy the calls to Encrypter.encrypt() just need an explicit code specified that lines up with the SignifyTS default: X25519_Cipher_Salt.