### PR TITLE
chore: bump SignifyPy to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "signifypy"
-version = "0.4.1"
+version = "0.4.2"
 description = "SignifyPy: KERI Signing at the Edge"
 readme = "README.md"
 license = { text = "Apache Software License 2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "signifypy"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "http-sfv" },


### PR DESCRIPTION
## Summary

Bump SignifyPy from `0.4.1` to `0.4.2` for the next patch release.

## Validation

- `.venv/bin/python -m pytest tests/core/test_versioning.py`
- `.venv/bin/python -m pytest`
- `/Users/kbull/.local/bin/uv build`

## Release Notes

This is a patch release prep PR containing only the package version bump in `pyproject.toml` and `uv.lock`.
