### PR TITLE
fix: drop agent EID suffix on multisig OOBI by default

### DIFF
--- a/src/signify/app/coring.py
+++ b/src/signify/app/coring.py
@@ -186,9 +186,13 @@ class Oobis:
         """Create an OOBI resource bound to one Signify client."""
         self.client = client
 
-    def get(self, name, role="agent"):
+    def get(self, name, role="agent", include_eid=None):
         """Return role-specific OOBIs published for one identifier alias."""
-        res = self.client.get(f"/identifiers/{name}/oobis?role={role}")
+        params = dict(role=role)
+        if include_eid is not None:
+            params["includeEid"] = str(include_eid).lower()
+
+        res = self.client.get(f"/identifiers/{name}/oobis", params=params)
         return res.json()
 
     def resolve(self, oobi, alias=None):

--- a/tests/app/test_coring.py
+++ b/tests/app/test_coring.py
@@ -264,11 +264,19 @@ def test_oobis_get(make_mock_response):
     oobis = coring.Oobis(client=client) # type: ignore
 
     mock_response = make_mock_response()
-    expect(client, times=1).get('/identifiers/a_name/oobis?role=my_role').thenReturn(mock_response)
+    expect(client, times=1).get(
+        '/identifiers/a_name/oobis',
+        params={'role': 'my_role'},
+    ).thenReturn(mock_response)
+    expect(client, times=1).get(
+        '/identifiers/a_name/oobis',
+        params={'role': 'my_role', 'includeEid': 'true'},
+    ).thenReturn(mock_response)
 
-    expect(mock_response, times=1).json().thenReturn({'some': 'json'})
+    expect(mock_response, times=2).json().thenReturn({'some': 'json'})
 
     oobis.get("a_name", "my_role")
+    oobis.get("a_name", "my_role", include_eid=True)
 
 def test_oobis_resolve(make_mock_response):
     from signify.app.clienting import SignifyClient

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1303,9 +1303,7 @@ def expose_multisig_agent_oobi(
        EID set.
     4. Each member waits for a non-empty group agent OOBI and both answers are
        compared to confirm convergence on one publication route.
-    5. Return the base multisig OOBI, not the raw `/agent/...` route. This
-       mirrors the SignifyTS multisig flows, which resolve the group OOBI
-       derived from the agent publication path.
+    5. Return KERIA's default group agent OOBI directly.
 
     Important contract detail:
     Once an embedded `rpy` is already locally approved, the peer echo may be
@@ -1342,7 +1340,13 @@ def expose_multisig_agent_oobi(
     agent_oobi_a = wait_for_identifier_oobi(client_a, group_name, role="agent")[0]
     agent_oobi_b = wait_for_identifier_oobi(client_b, group_name, role="agent")[0]
     assert agent_oobi_a == agent_oobi_b
-    return agent_oobi_a.split("/agent/")[0]
+    qualified_oobis = client_a.oobis().get(
+        group_name,
+        role="agent",
+        include_eid=True,
+    )["oobis"]
+    assert all("/agent/" in oobi for oobi in qualified_oobis)
+    return agent_oobi_a
 
 
 def expose_multisig_agent_oobi_n(
@@ -1392,7 +1396,7 @@ def expose_multisig_agent_oobi_n(
         oobis.append(wait_for_identifier_oobi(client, group_name, role="agent")[0])
 
     assert len(set(oobis)) == 1
-    return oobis[0].split("/agent/")[0]
+    return oobis[0]
 
 
 def start_multisig_rotation(

--- a/tests/integration/test_delegation.py
+++ b/tests/integration/test_delegation.py
@@ -178,8 +178,7 @@ def test_multisig_delegator_to_single_sig_delegate(client_factory):
         delegator_member_b_name,
         delegator_group_name,
     )
-    delegator_group_identifier_oobi = delegator_group_oobi.split("/agent/")[0]
-    resolve_oobi(delegate_client, delegator_group_identifier_oobi, alias=delegator_group_name)
+    resolve_oobi(delegate_client, delegator_group_oobi, alias=delegator_group_name)
 
     delegate_serder, delegate_operation = start_delegated_identifier(
         delegate_client,
@@ -278,9 +277,8 @@ def test_multisig_delegator_to_multisig_delegate(client_factory):
         delegator_member_b_name,
         delegator_group_name,
     )
-    delegator_group_identifier_oobi = delegator_group_oobi.split("/agent/")[0]
-    resolve_oobi(delegate_client_a, delegator_group_identifier_oobi, alias=delegator_group_name)
-    resolve_oobi(delegate_client_b, delegator_group_identifier_oobi, alias=delegator_group_name)
+    resolve_oobi(delegate_client_a, delegator_group_oobi, alias=delegator_group_name)
+    resolve_oobi(delegate_client_b, delegator_group_oobi, alias=delegator_group_name)
 
     delegate_participants = [
         delegate_client_a.identifiers().get(delegate_member_a_name)["prefix"],


### PR DESCRIPTION
This has been a constant source of confusion for years and should return the intuitive result by default, the multisig Agent OOBI with no agent EID suffix.

The includeEid URL parameter allows using the old behavior, if desired.

KERIA PR: https://github.com/WebOfTrust/keria/pull/447
SignifyTS PR: https://github.com/WebOfTrust/signify-ts/pull/400